### PR TITLE
Add POST /wishlists/{id}/items to create item in wishlist

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -23,7 +23,7 @@ and Delete Wishlist
 
 from flask import jsonify, request, url_for, abort
 from flask import current_app as app  # Import Flask application
-from service.models import Wishlist
+from service.models import Wishlist, Item
 from service.common import status  # HTTP Status Codes
 
 
@@ -109,6 +109,42 @@ def list_wishlist_items(wishlist_id):
 
     results = [item.serialize() for item in wishlist.items]
     return jsonify(results), status.HTTP_200_OK
+
+
+######################################################################
+# CREATE ITEM IN A WISHLIST
+######################################################################
+@app.route("/wishlists/<int:wishlist_id>/items", methods=["POST"])
+def create_wishlist_items(wishlist_id):
+    """
+    Create an Item in a Wishlist
+    This endpoint will create an Item in the specified Wishlist
+    """
+    app.logger.info("Request to Create an Item in wishlist id [%s]", wishlist_id)
+
+    wishlist = Wishlist.find(wishlist_id)
+    if not wishlist:
+        abort(status.HTTP_404_NOT_FOUND, f"Wishlist with id '{wishlist_id}' not found.")
+
+    check_content_type("application/json")
+
+    item = Item()
+    data = request.get_json()
+    data["wishlist_id"] = wishlist_id
+    app.logger.info("Processing: %s", data)
+    item.deserialize(data)
+
+    item.create()
+    app.logger.info("Item with new id [%s] saved!", item.id)
+
+    location_url = (
+        f"{request.url_root.rstrip('/')}/wishlists/{wishlist_id}/items/{item.id}"
+    )
+    return (
+        jsonify(item.serialize()),
+        status.HTTP_201_CREATED,
+        {"Location": location_url},
+    )
 
 
 ######################################################################

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -226,6 +226,56 @@ class TestYourResourceService(TestCase):
         self.assertIn("message", data)
 
     # ----------------------------------------------------------
+    # TEST CREATE ITEM IN A WISHLIST
+    # ----------------------------------------------------------
+    def test_create_item_in_wishlist(self):
+        """It should Create an Item in a Wishlist"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        test_item = ItemFactory(wishlist_id=wishlist.id)
+        item_data = {
+            "product_id": test_item.product_id,
+            "product_name": test_item.product_name,
+            "quantity": test_item.quantity,
+            "variant_id": test_item.variant_id,
+        }
+        response = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items", json=item_data
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        new_item = response.get_json()
+        location = response.headers.get("Location", None)
+        self.assertIsNotNone(location)
+        self.assertIn(str(new_item["id"]), location)
+        self.assertEqual(new_item["wishlist_id"], wishlist.id)
+        self.assertEqual(new_item["product_id"], test_item.product_id)
+        self.assertEqual(new_item["product_name"], test_item.product_name)
+        self.assertEqual(new_item["variant_id"], test_item.variant_id)
+
+        response = self.client.get(f"{BASE_URL}/{wishlist.id}/items")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["product_name"], test_item.product_name)
+
+    def test_create_item_wishlist_not_found(self):
+        """It should return 404 when creating an Item in a missing Wishlist"""
+        test_item = ItemFactory()
+        item_data = {
+            "product_id": test_item.product_id,
+            "product_name": test_item.product_name,
+            "quantity": test_item.quantity,
+            "variant_id": test_item.variant_id,
+        }
+        response = self.client.post(
+            f"{BASE_URL}/999999/items", json=item_data
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertIn("message", data)
+
+    # ----------------------------------------------------------
     # TEST CREATE
     # ----------------------------------------------------------
     def test_create_wishlist(self):
@@ -295,4 +345,76 @@ class TestSadPaths(TestCase):
         data = test_wishlist.serialize()
         del data["customer_id"]
         response = self.client.post(BASE_URL, json=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_item_no_data(self):
+        """It should not Create an Item with missing data"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        response = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items", json={}
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_item_no_content_type(self):
+        """It should not Create an Item with no content type"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        response = self.client.post(f"{BASE_URL}/{wishlist.id}/items")
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+
+    def test_create_item_wrong_content_type(self):
+        """It should not Create an Item with the wrong content type"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        response = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items",
+            data="hello",
+            content_type="text/html",
+        )
+        self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
+
+    def test_create_item_missing_product_id(self):
+        """It should not Create an Item with missing product_id"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        test_item = ItemFactory(wishlist_id=wishlist.id)
+        item_data = {
+            "product_name": test_item.product_name,
+            "quantity": test_item.quantity,
+            "variant_id": test_item.variant_id,
+        }
+        response = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items", json=item_data
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_item_missing_product_name(self):
+        """It should not Create an Item with missing product_name"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        test_item = ItemFactory(wishlist_id=wishlist.id)
+        item_data = {
+            "product_id": test_item.product_id,
+            "quantity": test_item.quantity,
+            "variant_id": test_item.variant_id,
+        }
+        response = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items", json=item_data
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_item_missing_variant_id(self):
+        """It should not Create an Item with missing variant_id"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        test_item = ItemFactory(wishlist_id=wishlist.id)
+        item_data = {
+            "product_id": test_item.product_id,
+            "product_name": test_item.product_name,
+            "quantity": test_item.quantity,
+        }
+        response = self.client.post(
+            f"{BASE_URL}/{wishlist.id}/items", json=item_data
+        )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary
Implements the CREATE/add item to wishlist story. Adds POST /wishlists/{wishlist_id}/items to create items in a specific wishlist.

## Changes
- **POST /wishlists/{wishlist_id}/items** – creates an item from JSON (product_id, product_name, variant_id, optional quantity); wishlist_id from URL path
- Validates wishlist exists before creating item (404 if not found)

## Route tests
- `test_create_item_in_wishlist` – happy path (201, Location, response body, verify via GET /items)
- `test_create_item_wishlist_not_found` – 404
- `test_create_item_no_data` – 400
- `test_create_item_no_content_type` – 415
- `test_create_item_wrong_content_type` – 415
- `test_create_item_missing_product_id` – 400
- `test_create_item_missing_product_name` – 400
- `test_create_item_missing_variant_id` – 400