### PR TITLE
 Read item from wishlist

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -196,13 +196,14 @@ def create_wishlists():
         {"Location": location_url},
     )
 
+
 ######################################################################
 # DELETE A WISHLIST
 ######################################################################
 @app.route("/wishlists/<int:wishlist_id>", methods=["DELETE"])
 def delete_wishlists(wishlist_id):
     """
-    Delete a Wishlist 
+    Delete a Wishlist
 
     This endpoint will delete a Wishlist based the id specified in the path
     """

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -374,7 +374,8 @@ class TestYourResourceService(TestCase):
         response = self.client.delete(f"{BASE_URL}/0")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(len(response.data), 0)
-        
+
+
 ######################################################################
 #  T E S T   S A D   P A T H S
 ######################################################################


### PR DESCRIPTION
## Summary
Implements the READ item from wishlist story. Adds GET /wishlists/{wishlist_id}/items/{item_id} to return a single item from a wishlist.

## Changes
- **GET /wishlists/{wishlist_id}/items/{item_id}** – returns item by id
- Verifies wishlist exists (404 if missing)
- Verifies item exists and belongs to wishlist (404 if missing or wrong wishlist)
- Returns 200 with item JSON

## Route tests
- `test_get_item_in_wishlist` – happy path (200, item data)
- `test_get_item_wishlist_not_found` – 404 when wishlist missing
- `test_get_item_not_found` – 404 when item missing
- `test_get_item_not_in_wishlist` – 404 when item belongs to another wishlist