### PR TITLE
Implement DELETE endpoint for removing items from wishlist

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -219,6 +219,37 @@ def delete_wishlists(wishlist_id):
     return {}, status.HTTP_204_NO_CONTENT
 
 
+######################################################################
+# DELETE AN ITEM FROM A WISHLIST
+######################################################################
+@app.route("/wishlists/<int:wishlist_id>/items/<int:item_id>", methods=["DELETE"])
+def delete_wishlist_item(wishlist_id, item_id):
+    """
+    Delete an Item from a Wishlist
+
+    This endpoint will delete an Item from the specified Wishlist
+    """
+    app.logger.info("Request to Delete item %s from wishlist %s", item_id, wishlist_id)
+
+    wishlist = Wishlist.find(wishlist_id)
+    if not wishlist:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Wishlist with id '{wishlist_id}' not found.",
+        )
+
+    item = Item.find(item_id)
+    if not item or item.wishlist_id != wishlist_id:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Item with id '{item_id}' not found in wishlist '{wishlist_id}'.",
+        )
+
+    item.delete()
+    app.logger.info("Item with ID: %d deleted.", item_id)
+    return {}, status.HTTP_204_NO_CONTENT
+
+
 @app.route("/wishlists/<int:wishlist_id>", methods=["PUT"])
 def update_wishlists(wishlist_id):
     """

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -364,6 +364,31 @@ class TestYourResourceService(TestCase):
         self.assertEqual(len(response.data), 0)
 
     # ----------------------------------------------------------
+    # TEST DELETE ITEM FROM WISHLIST
+    # ----------------------------------------------------------
+
+    def test_delete_item_from_wishlist(self):
+        """It should Delete an Item from a Wishlist"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        item = ItemFactory(wishlist_id=wishlist.id)
+        item.create()
+
+        # Verify item exists
+        response = self.client.get(f"{BASE_URL}/{wishlist.id}/items")
+        self.assertEqual(len(response.get_json()), 1)
+
+        # Delete the item
+        response = self.client.delete(f"{BASE_URL}/{wishlist.id}/items/{item.id}")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(len(response.data), 0)
+
+        # Verify item is gone
+        response = self.client.get(f"{BASE_URL}/{wishlist.id}/items")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.get_json()), 0)
+
+    # ----------------------------------------------------------
     # TEST UPDATE WISHLIST
     # ----------------------------------------------------------
     def test_update_wishlist(self):
@@ -549,3 +574,41 @@ class TestSadPaths(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         data = response.get_json()
         self.assertIn("message", data)
+
+    # ----------------------------------------------------------
+    # TEST DELETE ITEM SAD PATHS
+    # ----------------------------------------------------------
+
+    def test_delete_item_wishlist_not_found(self):
+        """It should return 404 when deleting an item from a non-existent wishlist"""
+        response = self.client.delete(f"{BASE_URL}/999999/items/1")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertIn("message", data)
+
+    def test_delete_item_not_found(self):
+        """It should return 404 when deleting a non-existent item"""
+        wishlist = WishlistFactory()
+        wishlist.create()
+        response = self.client.delete(f"{BASE_URL}/{wishlist.id}/items/999999")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertIn("message", data)
+
+    def test_delete_item_not_in_wishlist(self):
+        """It should return 404 when deleting an item that belongs to another wishlist"""
+        wishlist_a = WishlistFactory()
+        wishlist_a.create()
+        wishlist_b = WishlistFactory()
+        wishlist_b.create()
+        item = ItemFactory(wishlist_id=wishlist_a.id)
+        item.create()
+
+        response = self.client.delete(f"{BASE_URL}/{wishlist_b.id}/items/{item.id}")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertIn("message", data)
+
+        # Verify the item still exists in wishlist_a
+        response = self.client.get(f"{BASE_URL}/{wishlist_a.id}/items")
+        self.assertEqual(len(response.get_json()), 1)


### PR DESCRIPTION
Implemented DELETE item from wishlist endpoint (DELETE /wishlists/{id}/items/{item_id})

- Added DELETE /wishlists/<wishlist_id>/items/<item_id> route
  - Validates wishlist exists (404 if not found)
  - Validates item exists and belongs to the wishlist (404 if not found)
  - Deletes the item and returns 204 No Content on success
- Added route tests:
  - test_delete_item_from_wishlist (happy path: deletes item, returns 204, verifies removal)
  - test_delete_item_wishlist_not_found (sad path: non-existent wishlist returns 404)
  - test_delete_item_not_found (sad path: non-existent item returns 404)
  - test_delete_item_not_in_wishlist (sad path: item belongs to different wishlist returns 404)
- All 42 tests passed, service/routes.py at 100% coverage

Closes #6