### PR TITLE
Update root URL - add landing page and API routes table

### DIFF
--- a/service/landing.py
+++ b/service/landing.py
@@ -1,0 +1,33 @@
+"""
+HTML for the root landing page (GET /).
+"""
+
+
+def get_landing_html() -> str:
+    return """<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Wishlist Service</title></head>
+<body style="font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.5;">
+  <h1>Wishlist Service is Up</h1>
+  <p><strong>Wishlist REST API Service</strong> v1.0.</p>
+  <p>These are the routes we serve:</p>
+  <h2>Wishlists</h2>
+  <table border="1" cellpadding="8" cellspacing="0">
+    <tr><th>Method</th><th>Path</th><th>Description</th></tr>
+    <tr><td>GET</td><td>/wishlists</td><td>List wishlists</td></tr>
+    <tr><td>POST</td><td>/wishlists</td><td>Create a wishlist</td></tr>
+    <tr><td>GET</td><td>/wishlists/{wishlist_id}</td><td>Get one wishlist</td></tr>
+    <tr><td>PUT</td><td>/wishlists/{wishlist_id}</td><td>Update wishlist name/description</td></tr>
+    <tr><td>DELETE</td><td>/wishlists/{wishlist_id}</td><td>Delete a wishlist</td></tr>
+  </table>
+  <h2>Wishlist Items</h2>
+  <table border="1" cellpadding="8" cellspacing="0">
+    <tr><th>Method</th><th>Path</th><th>Description</th></tr>
+    <tr><td>GET</td><td>/wishlists/{wishlist_id}/items</td><td>List items in a wishlist</td></tr>
+    <tr><td>POST</td><td>/wishlists/{wishlist_id}/items</td><td>Create an item in a wishlist</td></tr>
+    <tr><td>GET</td><td>/wishlists/{wishlist_id}/items/{item_id}</td><td>Get one item in a wishlist</td></tr>
+    <tr><td>PUT</td><td>/wishlists/{wishlist_id}/items/{item_id}</td><td>Update item in wishlist</td></tr>
+    <tr><td>DELETE</td><td>/wishlists/{wishlist_id}/items/{item_id}</td><td>Delete item from wishlist</td></tr>
+  </table>
+</body>
+</html>"""

--- a/service/routes.py
+++ b/service/routes.py
@@ -25,23 +25,48 @@ from flask import jsonify, request, url_for, abort
 from flask import current_app as app  # Import Flask application
 from service.models import Wishlist, Item
 from service.common import status  # HTTP Status Codes
+from service.landing import get_landing_html
 
 
 ######################################################################
 # GET INDEX
 ######################################################################
+def _index_json():
+    return jsonify(
+        name="Wishlist REST API Service",
+        version="1.0",
+        message="Wishlist service is up",
+        paths=url_for("list_wishlists", _external=True),
+        endpoints={
+            "Wishlists": [
+                {"method": "GET", "path": "/wishlists", "description": "List wishlists"},
+                {"method": "POST", "path": "/wishlists", "description": "Create a wishlist"},
+                {"method": "GET", "path": "/wishlists/{wishlist_id}", "description": "Get one wishlist"},
+                {"method": "PUT", "path": "/wishlists/{wishlist_id}", "description": "Update wishlist name/description"},
+                {"method": "DELETE", "path": "/wishlists/{wishlist_id}", "description": "Delete a wishlist"},
+            ],
+            "Wishlist Items": [
+                {"method": "GET", "path": "/wishlists/{wishlist_id}/items", "description": "List items in a wishlist"},
+                {"method": "POST", "path": "/wishlists/{wishlist_id}/items", "description": "Create an item in a wishlist"},
+                {"method": "GET", "path": "/wishlists/{wishlist_id}/items/{item_id}", "description": "Get one item in a wishlist"},
+                {"method": "PUT", "path": "/wishlists/{wishlist_id}/items/{item_id}", "description": "Update item in wishlist"},
+                {"method": "DELETE", "path": "/wishlists/{wishlist_id}/items/{item_id}", "description": "Delete item from wishlist"},
+            ],
+        },
+    ), status.HTTP_200_OK
+
+
+def _index_html():
+    return get_landing_html(), status.HTTP_200_OK, {"Content-Type": "text/html; charset=utf-8"}
+
+
 @app.route("/")
 def index():
-    """Root URL response"""
+    """Root URL response – HTML landing page or JSON for API clients"""
     app.logger.info("Request for Root URL")
-    return (
-        jsonify(
-            name="Wishlist REST API Service",
-            version="1.0",
-            paths=url_for("list_wishlists", _external=True),
-        ),
-        status.HTTP_200_OK,
-    )
+    if "application/json" in request.headers.get("Accept", ""):
+        return _index_json()
+    return _index_html()
 
 
 ######################################################################


### PR DESCRIPTION
## Update root URL

- Root URL (`GET /`) now returns an HTML landing page with:
  - H1: "Wishlist Service is Up"
  - Tables listing all wishlist and item endpoints (method, path, description)
- Uses content negotiation: `Accept: application/json` still returns JSON.
- Landing HTML moved to `service/landing.py`; routing logic stays in `service/routes.py`.