### PR TITLE
Add Codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Python-3.12-blue.svg)](https://python.org)
+[![codecov](https://codecov.io/gh/CSCI-GA-2820-SP26-003/wishlists/branch/master/graph/badge.svg)](https://codecov.io/gh/CSCI-GA-2820-SP26-003/wishlists)
 
 ## Overview
 This Wishlist service is a REST API for managing wishlists and wishlist items. This code is modeled after the sample-accounts code which can be found [sample-accounts](https://github.com/nyu-devops/sample-accounts).


### PR DESCRIPTION
Added Codecov badge to display code coverage status at a glance.

## Changes
Added Codecov badge near existing badges (License, Python).

## Result
Developers can now quickly see the coverage status on the README.

The badge:
- Shows current coverage percentage
- Links to full Codecov report
- Updates automatically with each CI run

Closes #55

---

If this PR helped your project, tips are appreciated! 🙏
USDT (TRC20): `TJL2uq9nC6aqqGTDSUaUg8KWepSh8htrft`