### PR TITLE
Enhance CI lint task with parallel execution and failure handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,26 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  lint:
+    runs-on: ubuntu-latest
+    container: python:3.12-slim
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Python package dependencies
+        run: |
+          python -m pip install -U pip pipenv
+          pipenv install --system --dev
+
+      - name: Install system packages
+        run: apt-get update && apt-get install -y make git curl gpg
+
+      - name: Linting
+        run: make lint
+
+  test:
     runs-on: ubuntu-latest
     container: python:3.12-slim
 
@@ -41,9 +60,6 @@ jobs:
 
       - name: Install system packages
         run: apt-get update && apt-get install -y make git curl gpg
-
-      - name: Linting
-        run: make lint
 
       - name: Run tests with coverage
         run: pytest --pspec --cov=service --cov-fail-under=95 --cov-report=xml --disable-warnings

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,11 @@ install: ## Install Python dependencies
 .PHONY: lint
 lint: ## Run the linter
 	$(info Running linting...)
-	-flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics
-	-flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistics
-	-pylint service tests --max-line-length=127
+	@status=0; \
+	flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics || status=$$?; \
+	flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistics || status=$$?; \
+	pylint service tests --max-line-length=127 || status=$$?; \
+	exit $$status
 
 .PHONY: test
 test: ## Run the unit tests


### PR DESCRIPTION
Implemented CI lint task with parallel execution and enforced failure handling

The pipeline lint task from the user story was already partially present: the repository was already being analyzed with flake8 and pylint through the existing make lint target, and lint output was already visible in the pipeline logs.

The workflow was enhanced by separating linting into its own CI job, allowing it to run in parallel with the unit test job after checkout and dependency installation, which better aligns the pipeline with the story requirement to reduce execution time.

The lint behavior was also corrected in the Makefile. Although flake8 and pylint were already configured, their failures were being ignored, which allowed the pipeline to continue even when lint errors existed. The lint target was updated so all configured checks still run and report their results, but the pipeline now exits with failure when any linting errors are detected.