### PR TITLE
Add action route to set wishlist private

### DIFF
--- a/service/models/wishlist.py
+++ b/service/models/wishlist.py
@@ -23,6 +23,7 @@ class Wishlist(db.Model, PersistentBase):
     name = db.Column(db.String(63), nullable=False)
     customer_id = db.Column(db.Integer, nullable=False)
     description = db.Column(db.String(63), nullable=True)
+    is_private = db.Column(db.Boolean, nullable=False, default=False)
     created_at = timestamp_column()
     updated_at = timestamp_column()
 
@@ -45,6 +46,7 @@ class Wishlist(db.Model, PersistentBase):
             "name": self.name,
             "customer_id": self.customer_id,
             "description": self.description,
+            "is_private": self.is_private,
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
             "items": [item.serialize() for item in self.items],
@@ -61,6 +63,15 @@ class Wishlist(db.Model, PersistentBase):
             self.name = data["name"]
             self.customer_id = data["customer_id"]
             self.description = data.get("description")
+            if "is_private" in data:
+                raw_private = data["is_private"]
+                if not isinstance(raw_private, bool):
+                    raise DataValidationError(
+                        "Invalid Wishlist: is_private must be a boolean"
+                    )
+                self.is_private = raw_private
+            else:
+                self.is_private = False
             created_at = data.get("created_at")
             updated_at = data.get("updated_at")
             self.created_at = parse_timestamp(created_at)

--- a/service/routes.py
+++ b/service/routes.py
@@ -51,6 +51,11 @@ def _index_json():
                 {"method": "GET", "path": "/wishlists/{wishlist_id}", "description": "Get one wishlist"},
                 {"method": "PUT", "path": "/wishlists/{wishlist_id}", "description": "Update wishlist name/description"},
                 {"method": "DELETE", "path": "/wishlists/{wishlist_id}", "description": "Delete a wishlist"},
+                {
+                    "method": "POST",
+                    "path": "/wishlists/{wishlist_id}/private",
+                    "description": "Action: set wishlist privacy to private",
+                },
             ],
             "Wishlist Items": [
                 {
@@ -142,6 +147,24 @@ def get_wishlist(wishlist_id):
     if not wishlist:
         abort(status.HTTP_404_NOT_FOUND, f"Wishlist with id '{wishlist_id}' not found.")
 
+    return jsonify(wishlist.serialize()), status.HTTP_200_OK
+
+
+######################################################################
+# ACTION: SET WISHLIST TO PRIVATE
+######################################################################
+@app.route("/wishlists/<int:wishlist_id>/private", methods=["POST"])
+def set_wishlist_private(wishlist_id):
+    """Action: mark a wishlist as private (not a generic CRUD update)."""
+    app.logger.info("Request to set wishlist id [%s] to private", wishlist_id)
+    wishlist = Wishlist.find(wishlist_id)
+    if not wishlist:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Wishlist with id '{wishlist_id}' not found.",
+        )
+    wishlist.is_private = True
+    wishlist.update()
     return jsonify(wishlist.serialize()), status.HTTP_200_OK
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -19,6 +19,7 @@ class WishlistFactory(Factory):
     name = Faker("word")
     customer_id = Sequence(lambda n: n + 1000)
     description = Faker("sentence", nb_words=4)
+    is_private = False
     created_at = Faker("date_time", tzinfo=timezone.utc)
     updated_at = Faker("date_time", tzinfo=timezone.utc)
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -472,6 +472,29 @@ class TestYourResourceService(TestCase):
         self.assertEqual(new_wishlist["name"], test_wishlist.name)
         self.assertEqual(new_wishlist["customer_id"], test_wishlist.customer_id)
         self.assertEqual(new_wishlist["description"], test_wishlist.description)
+        self.assertFalse(new_wishlist["is_private"])
+
+    # ----------------------------------------------------------
+    # TEST ACTION: SET WISHLIST PRIVATE
+    # ----------------------------------------------------------
+
+    def test_set_wishlist_private(self):
+        """It should set a wishlist to private via the action route"""
+        wishlist = self._create_wishlists(1)[0]
+        self.assertFalse(wishlist.is_private)
+
+        resp = self.client.post(f"{BASE_URL}/{wishlist.id}/private")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        data = resp.get_json()
+        self.assertTrue(data["is_private"])
+
+        again = Wishlist.find(wishlist.id)
+        self.assertTrue(again.is_private)
+
+    def test_set_wishlist_private_not_found(self):
+        """It should return 404 when setting privacy on a missing wishlist"""
+        resp = self.client.post(f"{BASE_URL}/999999/private")
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     # ----------------------------------------------------------
     # TEST DELETE

--- a/tests/test_wishlist_model.py
+++ b/tests/test_wishlist_model.py
@@ -177,6 +177,8 @@ class TestWishlist(TestCase):
         self.assertEqual(serial["name"], wishlist.name)
         self.assertEqual(serial["customer_id"], wishlist.customer_id)
         self.assertEqual(serial["description"], wishlist.description)
+        self.assertIn("is_private", serial)
+        self.assertFalse(serial["is_private"])
         self.assertEqual(len(serial["items"]), 1)
 
     def test_deserialize_a_wishlist(self):
@@ -199,6 +201,17 @@ class TestWishlist(TestCase):
         """It should not deserialize a Wishlist with a TypeError"""
         wishlist = Wishlist()
         self.assertRaises(DataValidationError, wishlist.deserialize, [])
+
+    def test_deserialize_is_private_must_be_boolean(self):
+        """It should reject non-boolean is_private"""
+        wishlist = Wishlist()
+        data = {
+            "name": "Test",
+            "customer_id": 1,
+            "description": "Test",
+            "is_private": "yes",
+        }
+        self.assertRaises(DataValidationError, wishlist.deserialize, data)
 
     def test_deserialize_wishlist_invalid_datetime(self):
         """It should not deserialize a Wishlist with invalid datetime"""


### PR DESCRIPTION
## Summary
- adds a stateful action route: `POST /wishlists/{wishlist_id}/private`
- adds `is_private` to the `Wishlist` model (default `false`) and includes it in serialization
- updates wishlist deserialization to validate `is_private` as a boolean when provided
- adds tests for:
  - action route happy path (wishlist becomes private)
  - action route sad path (404 for missing wishlist)
  - model serialization/validation for `is_private`

## Verification
- `make lint`
- `make test`
- manual API check:
  - create a wishlist
  - call `POST /wishlists/{id}/private`
  - verify response and subsequent `GET /wishlists/{id}` include `"is_private": true`