### PR TITLE
Implemented wishlist retrieval from the web UI

### DIFF
--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -19,7 +19,10 @@ def step_impl(context):
 @when('I set the "{element_name}" to "{text_string}"')
 def step_impl(context, element_name, text_string):
     """Fill in a text input or textarea."""
-    element_id = ID_PREFIX + element_name.lower().replace(" ", "_")
+    normalized_name = element_name.lower().replace(" ", "_")
+    element_id = ID_PREFIX + normalized_name
+    if normalized_name.startswith("wishlist_"):
+        element_id = normalized_name
     element = context.driver.find_element(By.ID, element_id)
     element.clear()
     element.send_keys(text_string)

--- a/features/steps/wishlist_steps.py
+++ b/features/steps/wishlist_steps.py
@@ -47,3 +47,65 @@ def step_no_wishlists_exist(context):
             timeout=WAIT_TIMEOUT,
         )
         assert delete_resp.status_code == HTTP_204_NO_CONTENT
+
+
+@given("a wishlist exists")
+def step_wishlist_exists(context):
+    """Create one wishlist through the UI for retrieval tests."""
+    context.driver.get(context.base_url)
+    context.driver.find_element(By.ID, "wishlist_name").send_keys("Gaming Setup")
+    context.driver.find_element(By.ID, "wishlist_customer_id").send_keys("12345")
+    context.driver.find_element(By.ID, "wishlist_description").send_keys(
+        "PC and peripherals"
+    )
+    context.driver.find_element(By.ID, "create-btn").click()
+
+    found = WebDriverWait(context.driver, context.wait_seconds).until(
+        ec.text_to_be_present_in_element((By.ID, "flash_message"), "Success")
+    )
+    assert found
+
+    context.wishlist = {
+        "id": int(
+            context.driver.find_element(By.ID, "wishlist_id").get_attribute("value")
+        ),
+        "name": "Gaming Setup",
+        "customer_id": 12345,
+        "description": "PC and peripherals",
+    }
+
+
+@when("I retrieve the wishlist by ID")
+def step_retrieve_wishlist_by_id(context):
+    """Enter the wishlist id and click Retrieve in the UI."""
+    wishlist_id = str(context.wishlist["id"])
+    id_input = context.driver.find_element(By.ID, "wishlist_id")
+    id_input.clear()
+    id_input.send_keys(wishlist_id)
+    context.driver.find_element(By.ID, "retrieve-btn").click()
+
+
+@then("I should see the wishlist details")
+def step_see_wishlist_details(context):
+    """Ensure retrieval succeeded and details are shown in UI."""
+    found = WebDriverWait(context.driver, context.wait_seconds).until(
+        ec.text_to_be_present_in_element((By.ID, "flash_message"), "Success")
+    )
+    assert found
+    table_text = context.driver.find_element(By.ID, "search_results").text
+    assert str(context.wishlist["id"]) in table_text
+
+
+@then("I should see the correct wishlist information")
+def step_see_correct_wishlist_information(context):
+    """Validate key fields shown on the page match the created wishlist."""
+    assert context.driver.find_element(By.ID, "wishlist_id").get_attribute(
+        "value"
+    ) == str(context.wishlist["id"])
+    assert (
+        context.driver.find_element(By.ID, "wishlist_name").get_attribute("value")
+        == context.wishlist["name"]
+    )
+    assert context.driver.find_element(By.ID, "wishlist_customer_id").get_attribute(
+        "value"
+    ) == str(context.wishlist["customer_id"])

--- a/features/wishlist.feature
+++ b/features/wishlist.feature
@@ -8,3 +8,22 @@ Feature: Wishlist UI landing page
 		When I visit the home page
 		Then I should see "Wishlist Service is Up"
 		And I should see "These are the routes we serve"
+
+	Scenario: Retrieve a wishlist by ID from the web UI
+		Given I am on the "Home Page"
+		And a wishlist exists
+		When I retrieve the wishlist by ID
+		Then I should see the wishlist details
+		And I should see the correct wishlist information
+
+	Scenario: Retrieve with an invalid wishlist ID format
+		Given I am on the "Home Page"
+		When I set the "wishlist id" to "abc"
+		And I press the "Retrieve" button
+		Then I should see the message "Wishlist ID must be an integer"
+
+	Scenario: Retrieve a wishlist that does not exist
+		Given I am on the "Home Page"
+		When I set the "wishlist id" to "0"
+		And I press the "Retrieve" button
+		Then I should see the message "Wishlist with id '0' not found."

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -33,7 +33,7 @@
   <form>
     <p>
       <label for="wishlist_id">Wishlist ID:</label><br>
-      <input type="text" id="wishlist_id" readonly>
+      <input type="text" id="wishlist_id">
     </p>
     <p>
       <label for="wishlist_name">Name:</label><br>
@@ -49,6 +49,7 @@
     </p>
     <p>
       <button type="button" id="create-btn">Create</button>
+      <button type="button" id="retrieve-btn">Retrieve</button>
       <button type="button" id="search-btn">Search</button>
     </p>
   </form>

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -84,6 +84,20 @@
         return parsed;
     }
 
+    function parseWishlistId(rawValue) {
+        const trimmed = rawValue.trim();
+        if (!trimmed) {
+            throw new Error("Wishlist ID is required");
+        }
+
+        const parsed = Number.parseInt(trimmed, 10);
+        if (Number.isNaN(parsed)) {
+            throw new Error("Wishlist ID must be an integer");
+        }
+
+        return parsed;
+    }
+
     function collectCreatePayload() {
         const name = getField("wishlist_name").value.trim();
         const description = getField("wishlist_description").value.trim();
@@ -158,6 +172,25 @@
         }
     }
 
+    async function retrieveWishlist() {
+        try {
+            const wishlistId = parseWishlistId(getField("wishlist_id").value);
+            const wishlist = await requestJson("/wishlists/" + wishlistId, {
+                method: "GET",
+                headers: {
+                    "Accept": "application/json"
+                }
+            });
+
+            updateFormData(wishlist);
+            renderResults([wishlist]);
+            flashMessage("Success");
+        } catch (error) {
+            flashMessage(error.message);
+        }
+    }
+
     getField("create-btn").addEventListener("click", createWishlist);
+    getField("retrieve-btn").addEventListener("click", retrieveWishlist);
     getField("search-btn").addEventListener("click", searchWishlists);
 })();

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -112,6 +112,7 @@ class TestYourResourceService(TestCase):
         self.assertIn(b'id="wishlist_name"', resp.data)
         self.assertIn(b'id="wishlist_customer_id"', resp.data)
         self.assertIn(b'id="create-btn"', resp.data)
+        self.assertIn(b'id="retrieve-btn"', resp.data)
         self.assertIn(b'id="search_results"', resp.data)
 
     def test_health_endpoint(self):
@@ -281,7 +282,9 @@ class TestYourResourceService(TestCase):
         ItemFactory(wishlist_id=wishlist.id, product_name="Backpack").create()
         ItemFactory(wishlist_id=wishlist.id, product_name="Sneakers").create()
 
-        response = self.client.get(f"{BASE_URL}/{wishlist.id}/items?product_name=Sneakers")
+        response = self.client.get(
+            f"{BASE_URL}/{wishlist.id}/items?product_name=Sneakers"
+        )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.get_json()
         self.assertEqual(len(data), 2)


### PR DESCRIPTION
I implemented the Retrieve flow from the browser with an editable wishlist ID field and a dedicated Retrieve button. I implemented client-side ID validation and form/result rendering for the retrieved wishlist. I added UI-driven BDD coverage for the happy path plus two supporting cases not stated in the story: invalid ID format and missing wishlist. I updated the route test to verify the new UI control.