### PR TITLE
Implemented deleting a wishlist from the web UI

### DIFF
--- a/features/steps/wishlist_steps.py
+++ b/features/steps/wishlist_steps.py
@@ -127,6 +127,41 @@ def step_see_correct_wishlist_information(context):
     ) == str(context.wishlist["customer_id"])
 
 
+@when("I delete the wishlist by ID")
+def step_delete_wishlist_by_id(context):
+    """Enter the wishlist id and click Delete in the UI."""
+    wishlist_id = str(context.wishlist["id"])
+    id_input = context.driver.find_element(By.ID, "wishlist_id")
+    id_input.clear()
+    id_input.send_keys(wishlist_id)
+    context.driver.find_element(By.ID, "delete-btn").click()
+
+
+@then("I should not see the deleted wishlist in the results")
+def step_deleted_wishlist_not_in_results(context):
+    """Search by customer and confirm the deleted wishlist id is absent."""
+    customer_input = context.driver.find_element(By.ID, "wishlist_customer_id")
+    customer_input.clear()
+    customer_input.send_keys(str(context.wishlist["customer_id"]))
+    context.driver.execute_script(
+        "document.getElementById('flash_message').textContent = '';"
+    )
+    context.driver.find_element(By.ID, "search-btn").click()
+
+    found = WebDriverWait(context.driver, context.wait_seconds).until(
+        ec.text_to_be_present_in_element((By.ID, "flash_message"), "Success")
+    )
+    assert found
+    rows = context.driver.find_elements(By.CSS_SELECTOR, "#results_body tr")
+    returned_ids = []
+    for row in rows:
+        cells = row.find_elements(By.TAG_NAME, "td")
+        if len(cells) >= 1:
+            returned_ids.append(cells[0].text.strip())
+
+    assert str(context.wishlist["id"]) not in returned_ids
+
+
 @given("multiple wishlists exist")
 def step_multiple_wishlists_exist(context):
     step_no_wishlists_exist(context)

--- a/features/wishlist.feature
+++ b/features/wishlist.feature
@@ -1,41 +1,53 @@
 Feature: Wishlist UI landing page
-	As a developer
-	I need a BDD environment with behave and Selenium
-	So that I can verify the Wishlist UI is reachable and renders expected content
+  As a developer
+  I need a BDD environment with behave and Selenium
+  So that I can verify the Wishlist UI is reachable and renders expected content
 
-	Scenario: Open the wishlist landing page
-		Given the Wishlist service is running
-		When I visit the home page
-		Then I should see "Wishlist Service is Up"
-		And I should see "These are the routes we serve"
+  Scenario: Open the wishlist landing page
+    Given the Wishlist service is running
+    When I visit the home page
+    Then I should see "Wishlist Service is Up"
+    And I should see "These are the routes we serve"
 
-	Scenario: Retrieve a wishlist by ID from the web UI
-		Given I am on the "Home Page"
-		And a wishlist exists
-		When I retrieve the wishlist by ID
-		Then I should see the wishlist details
-		And I should see the correct wishlist information
+  Scenario: Retrieve a wishlist by ID from the web UI
+    Given I am on the "Home Page"
+    And a wishlist exists
+    When I retrieve the wishlist by ID
+    Then I should see the wishlist details
+    And I should see the correct wishlist information
 
-	Scenario: Retrieve with an invalid wishlist ID format
-		Given I am on the "Home Page"
-		When I set the "wishlist id" to "abc"
-		And I press the "Retrieve" button
-		Then I should see the message "Wishlist ID must be an integer"
+  Scenario: Retrieve with an invalid wishlist ID format
+    Given I am on the "Home Page"
+    When I set the "wishlist id" to "abc"
+    And I press the "Retrieve" button
+    Then I should see the message "Wishlist ID must be an integer"
 
-	Scenario: Retrieve a wishlist that does not exist
-		Given I am on the "Home Page"
-		When I set the "wishlist id" to "0"
-		And I press the "Retrieve" button
-		Then I should see the message "Wishlist with id '0' not found."
+  Scenario: Retrieve a wishlist that does not exist
+    Given I am on the "Home Page"
+    When I set the "wishlist id" to "0"
+    And I press the "Retrieve" button
+    Then I should see the message "Wishlist with id '0' not found."
 
-	Scenario: List all wishlists from the web UI
-		Given I am on the "Home Page"
-		And multiple wishlists exist
-		When I press the "Search" button
-		Then I should see all wishlists in the results
+  Scenario: Delete a wishlist by ID from the web UI
+    Given I am on the "Home Page"
+    And a wishlist exists
+    When I delete the wishlist by ID
+    Then I should see the message "Success"
 
-	Scenario: List returns more than one wishlist in the results
-		Given I am on the "Home Page"
-		And multiple wishlists exist
-		When I search for wishlists
-		Then I should see more than one wishlist in the results
+  Scenario: Deleted wishlist no longer appears in results
+    Given I am on the "Home Page"
+    And a wishlist exists
+    When I delete the wishlist by ID
+    Then I should not see the deleted wishlist in the results
+
+  Scenario: List all wishlists from the web UI
+    Given I am on the "Home Page"
+    And multiple wishlists exist
+    When I press the "Search" button
+    Then I should see all wishlists in the results
+
+  Scenario: List returns more than one wishlist in the results
+    Given I am on the "Home Page"
+    And multiple wishlists exist
+    When I search for wishlists
+    Then I should see more than one wishlist in the results

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -50,6 +50,7 @@
     <p>
       <button type="button" id="create-btn">Create</button>
       <button type="button" id="retrieve-btn">Retrieve</button>
+      <button type="button" id="delete-btn">Delete</button>
       <button type="button" id="search-btn">Search</button>
     </p>
   </form>

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -190,7 +190,26 @@
         }
     }
 
+    async function deleteWishlist() {
+        try {
+            const wishlistId = parseWishlistId(getField("wishlist_id").value);
+            await requestJson("/wishlists/" + wishlistId, {
+                method: "DELETE",
+                headers: {
+                    "Accept": "application/json"
+                }
+            });
+
+            renderResults([]);
+            updateFormData({});
+            flashMessage("Success");
+        } catch (error) {
+            flashMessage(error.message);
+        }
+    }
+
     getField("create-btn").addEventListener("click", createWishlist);
     getField("retrieve-btn").addEventListener("click", retrieveWishlist);
+    getField("delete-btn").addEventListener("click", deleteWishlist);
     getField("search-btn").addEventListener("click", searchWishlists);
 })();

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -113,6 +113,7 @@ class TestYourResourceService(TestCase):
         self.assertIn(b'id="wishlist_customer_id"', resp.data)
         self.assertIn(b'id="create-btn"', resp.data)
         self.assertIn(b'id="retrieve-btn"', resp.data)
+        self.assertIn(b'id="delete-btn"', resp.data)
         self.assertIn(b'id="search_results"', resp.data)
 
     def test_health_endpoint(self):


### PR DESCRIPTION
I implemented a Delete button on the Home Page and wired it to delete a wishlist by ID from the UI.\nI implemented success feedback and UI state updates so deleted wishlists are cleared from the form and results.\nI implemented BDD coverage for delete success and post-delete absence in results.\nI added supporting validation and deterministic verification logic beyond the story text: exact ID-based absence checks after deletion.\nI updated the route UI test to assert the Delete button is present.