### PR TITLE
Update Wishlist from WebUI

### DIFF
--- a/features/steps/wishlist_steps.py
+++ b/features/steps/wishlist_steps.py
@@ -207,6 +207,7 @@ def step_see_more_than_one_wishlist_in_results(context):
     rows = context.driver.find_elements(By.CSS_SELECTOR, "#results_body tr")
     assert len(rows) > 1
 
+
 @then('I should not see "{text}" in the results')
 def step_should_not_see_in_results(context, text):
     """Assert the results table does NOT contain the given text."""
@@ -215,3 +216,45 @@ def step_should_not_see_in_results(context, text):
     )
     table_text = context.driver.find_element(By.ID, "search_results").text
     assert text not in table_text
+
+
+@then('the wishlist name should be updated to "{name}"')
+def step_wishlist_name_updated(context, name):
+    """Verify the updated wishlist name is shown in the UI and persisted."""
+    assert (
+        context.driver.find_element(By.ID, "wishlist_name").get_attribute("value")
+        == name
+    )
+    table_text = context.driver.find_element(By.ID, "search_results").text
+    assert name in table_text
+
+    response = requests.get(
+        f"{context.base_url}/wishlists/{context.wishlist['id']}",
+        timeout=WAIT_TIMEOUT,
+    )
+    assert response.status_code == HTTP_200_OK
+    updated_wishlist = response.json()
+    assert updated_wishlist["name"] == name
+    context.wishlist["name"] = name
+
+
+@then('the wishlist description should be updated to "{description}"')
+def step_wishlist_description_updated(context, description):
+    """Verify the updated wishlist description is shown in the UI and persisted."""
+    assert (
+        context.driver.find_element(By.ID, "wishlist_description").get_attribute(
+            "value"
+        )
+        == description
+    )
+    table_text = context.driver.find_element(By.ID, "search_results").text
+    assert description in table_text
+
+    response = requests.get(
+        f"{context.base_url}/wishlists/{context.wishlist['id']}",
+        timeout=WAIT_TIMEOUT,
+    )
+    assert response.status_code == HTTP_200_OK
+    updated_wishlist = response.json()
+    assert updated_wishlist["description"] == description
+    context.wishlist["description"] = description

--- a/features/wishlist.feature
+++ b/features/wishlist.feature
@@ -34,6 +34,24 @@ Feature: Wishlist UI landing page
     When I delete the wishlist by ID
     Then I should see the message "Success"
 
+  Scenario: Update a wishlist name from the web UI
+    Given I am on the "Home Page"
+    And a wishlist exists
+    When I retrieve the wishlist by ID
+    And I set the "wishlist name" to "Outdoor Essentials"
+    And I press the "Update" button
+    Then I should see the message "Success"
+    And the wishlist name should be updated to "Outdoor Essentials"
+
+  Scenario: Update a wishlist description from the web UI
+    Given I am on the "Home Page"
+    And a wishlist exists
+    When I retrieve the wishlist by ID
+    And I set the "wishlist description" to "Updated wishlist description"
+    And I press the "Update" button
+    Then I should see the message "Success"
+    And the wishlist description should be updated to "Updated wishlist description"
+
   Scenario: Deleted wishlist no longer appears in results
     Given I am on the "Home Page"
     And a wishlist exists

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -28,7 +28,7 @@
     <tr><td>PUT</td><td>/wishlists/{wishlist_id}/items/{item_id}</td><td>Update item in wishlist</td></tr>
     <tr><td>DELETE</td><td>/wishlists/{wishlist_id}/items/{item_id}</td><td>Delete item from wishlist</td></tr>
   </table>
-  <h2>Create and Search Wishlists</h2>
+  <h2>Create, Retrieve, Update, Delete, and Search Wishlists</h2>
   <p>Status: <span id="flash_message"></span></p>
   <form>
     <p>
@@ -49,6 +49,7 @@
     </p>
     <p>
       <button type="button" id="create-btn">Create</button>
+      <button type="button" id="update-btn">Update</button>
       <button type="button" id="retrieve-btn">Retrieve</button>
       <button type="button" id="delete-btn">Delete</button>
       <button type="button" id="search-btn">Search</button>

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -46,11 +46,21 @@
     }
 
     async function parseJsonResponse(response) {
+        if (response.status === 204 || response.status === 205) {
+            return null;
+        }
+
         const contentType = response.headers.get("content-type") || "";
         if (!contentType.includes("application/json")) {
             return null;
         }
-        return response.json();
+
+        const responseText = await response.text();
+        if (!responseText.trim()) {
+            return null;
+        }
+
+        return JSON.parse(responseText);
     }
 
     async function requestJson(url, options) {
@@ -111,6 +121,20 @@
             name: name,
             customer_id: customerId,
             description: description || null
+        };
+    }
+
+    function collectUpdatePayload() {
+        const name = getField("wishlist_name").value.trim();
+        const description = getField("wishlist_description").value.trim();
+
+        if (!name) {
+            throw new Error("Name is required");
+        }
+
+        return {
+            name: name,
+            description: description
         };
     }
 
@@ -190,6 +214,26 @@
         }
     }
 
+    async function updateWishlist() {
+        try {
+            const wishlistId = parseWishlistId(getField("wishlist_id").value);
+            const wishlist = await requestJson("/wishlists/" + wishlistId, {
+                method: "PUT",
+                headers: {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify(collectUpdatePayload())
+            });
+
+            updateFormData(wishlist);
+            renderResults([wishlist]);
+            flashMessage("Success");
+        } catch (error) {
+            flashMessage(error.message);
+        }
+    }
+
     async function deleteWishlist() {
         try {
             const wishlistId = parseWishlistId(getField("wishlist_id").value);
@@ -209,6 +253,7 @@
     }
 
     getField("create-btn").addEventListener("click", createWishlist);
+    getField("update-btn").addEventListener("click", updateWishlist);
     getField("retrieve-btn").addEventListener("click", retrieveWishlist);
     getField("delete-btn").addEventListener("click", deleteWishlist);
     getField("search-btn").addEventListener("click", searchWishlists);

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -112,6 +112,7 @@ class TestYourResourceService(TestCase):
         self.assertIn(b'id="wishlist_name"', resp.data)
         self.assertIn(b'id="wishlist_customer_id"', resp.data)
         self.assertIn(b'id="create-btn"', resp.data)
+        self.assertIn(b'id="update-btn"', resp.data)
         self.assertIn(b'id="retrieve-btn"', resp.data)
         self.assertIn(b'id="delete-btn"', resp.data)
         self.assertIn(b'id="search_results"', resp.data)


### PR DESCRIPTION
- adds an Update button and frontend PUT flow so admins can edit wishlist name/description
- refreshes the UI with the saved values
- adds BDD/UI test coverage. 
- fixes empty 204 delete-response handling in the frontend.