### PR TITLE
flask rest plus swagger refactor

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 flask = "==3.1.2"
+flask-restx = "==1.3.0"
 flask-sqlalchemy = "==3.1.1"
 psycopg = {extras = ["binary"], version = "==3.3.2"}
 retry2 = "==0.9.5"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ef957f8132bdbca1655c5c10d2fe4666e89c94cd0521913aea434da59cea9341"
+            "sha256": "9e61b6ca1f2d41dbf6ba7241932bcb6a8e75b0974f46688b595409f74c133684"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,21 @@
         ]
     },
     "default": {
+        "aniso8601": {
+            "hashes": [
+                "sha256:25488f8663dd1528ae1f54f94ac1ea51ae25b4d531539b8bc707fed184d16845",
+                "sha256:eb19717fd4e0db6de1aab06f12450ab92144246b257423fe020af5748c0cb89e"
+            ],
+            "version": "==10.0.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309",
+                "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==26.1.0"
+        },
         "blinker": {
             "hashes": [
                 "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf",
@@ -26,11 +41,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a",
-                "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"
+                "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5",
+                "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.3.1"
+            "version": "==8.3.2"
         },
         "decorator": {
             "hashes": [
@@ -49,6 +64,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==3.1.2"
         },
+        "flask-restx": {
+            "hashes": [
+                "sha256:4f3d3fa7b6191fcc715b18c201a12cd875176f92ba4acc61626ccfd571ee1728",
+                "sha256:636c56c3fb3f2c1df979e748019f084a938c4da2035a3e535a4673e4fc177691"
+            ],
+            "index": "pypi",
+            "version": "==1.3.0"
+        },
         "flask-sqlalchemy": {
             "hashes": [
                 "sha256:4ba4be7f419dc72f4efd8802d69974803c37259dd42f3913b0dcf75c9447e0a0",
@@ -58,65 +81,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.1.1"
         },
-        "greenlet": {
-            "hashes": [
-                "sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd",
-                "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082",
-                "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b",
-                "sha256:1e692b2dae4cc7077cbb11b47d258533b48c8fde69a33d0d8a82e2fe8d8531d5",
-                "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f",
-                "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727",
-                "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e",
-                "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2",
-                "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f",
-                "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327",
-                "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd",
-                "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2",
-                "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070",
-                "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99",
-                "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be",
-                "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79",
-                "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7",
-                "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e",
-                "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf",
-                "sha256:5d0e35379f93a6d0222de929a25ab47b5eb35b5ef4721c2b9cbcc4036129ff1f",
-                "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506",
-                "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a",
-                "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395",
-                "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4",
-                "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca",
-                "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492",
-                "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab",
-                "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358",
-                "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce",
-                "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5",
-                "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef",
-                "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d",
-                "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac",
-                "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55",
-                "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124",
-                "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4",
-                "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986",
-                "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd",
-                "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f",
-                "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb",
-                "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4",
-                "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13",
-                "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab",
-                "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff",
-                "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a",
-                "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9",
-                "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86",
-                "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd",
-                "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71",
-                "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92",
-                "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643",
-                "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54",
-                "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9"
-            ],
-            "markers": "python_version >= '3.10'",
-            "version": "==3.3.2"
-        },
         "gunicorn": {
             "hashes": [
                 "sha256:aca364c096c81ca11acd4cede0aaeea91ba76ca74e2c0d7f879154db9d890f35",
@@ -125,6 +89,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.10'",
             "version": "==25.0.3"
+        },
+        "importlib-resources": {
+            "hashes": [
+                "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708",
+                "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==7.1.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -141,6 +113,22 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==3.1.6"
+        },
+        "jsonschema": {
+            "hashes": [
+                "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326",
+                "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==4.26.0"
+        },
+        "jsonschema-specifications": {
+            "hashes": [
+                "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe",
+                "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==2025.9.1"
         },
         "markupsafe": {
             "hashes": [
@@ -239,11 +227,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
-                "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
+                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
+                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.0"
+            "version": "==26.1"
         },
         "psycopg": {
             "extras": [
@@ -326,6 +314,21 @@
             "markers": "python_version >= '3.10'",
             "version": "==1.2.2"
         },
+        "pytz": {
+            "hashes": [
+                "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1",
+                "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a"
+            ],
+            "version": "==2026.1.post1"
+        },
+        "referencing": {
+            "hashes": [
+                "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231",
+                "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==0.37.0"
+        },
         "retry2": {
             "hashes": [
                 "sha256:f7fee13b1e15d0611c462910a6aa72a8919823988dd0412152bc3719c89a4e55"
@@ -334,74 +337,195 @@
             "markers": "python_version >= '2.6'",
             "version": "==0.9.5"
         },
+        "rpds-py": {
+            "hashes": [
+                "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f",
+                "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136",
+                "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3",
+                "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7",
+                "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65",
+                "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4",
+                "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169",
+                "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf",
+                "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4",
+                "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2",
+                "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c",
+                "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4",
+                "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3",
+                "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6",
+                "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7",
+                "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89",
+                "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85",
+                "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6",
+                "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa",
+                "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb",
+                "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6",
+                "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87",
+                "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856",
+                "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4",
+                "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f",
+                "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53",
+                "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229",
+                "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad",
+                "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23",
+                "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db",
+                "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038",
+                "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27",
+                "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00",
+                "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18",
+                "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083",
+                "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c",
+                "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738",
+                "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898",
+                "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e",
+                "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7",
+                "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08",
+                "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6",
+                "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551",
+                "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e",
+                "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288",
+                "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df",
+                "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0",
+                "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2",
+                "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05",
+                "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0",
+                "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464",
+                "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5",
+                "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404",
+                "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7",
+                "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139",
+                "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394",
+                "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb",
+                "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15",
+                "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff",
+                "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed",
+                "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6",
+                "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e",
+                "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95",
+                "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d",
+                "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950",
+                "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3",
+                "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5",
+                "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97",
+                "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e",
+                "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e",
+                "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b",
+                "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd",
+                "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad",
+                "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8",
+                "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425",
+                "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221",
+                "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d",
+                "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825",
+                "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51",
+                "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e",
+                "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f",
+                "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8",
+                "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f",
+                "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d",
+                "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07",
+                "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877",
+                "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31",
+                "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58",
+                "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94",
+                "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28",
+                "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000",
+                "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1",
+                "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1",
+                "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7",
+                "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7",
+                "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40",
+                "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d",
+                "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0",
+                "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84",
+                "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f",
+                "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a",
+                "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7",
+                "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419",
+                "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8",
+                "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a",
+                "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9",
+                "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be",
+                "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed",
+                "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a",
+                "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d",
+                "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324",
+                "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f",
+                "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2",
+                "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f",
+                "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==0.30.0"
+        },
         "sqlalchemy": {
             "hashes": [
-                "sha256:01f6bbd4308b23240cf7d3ef117557c8fd097ec9549d5d8a52977544e35b40ad",
-                "sha256:07edba08061bc277bfdc772dd2a1a43978f5a45994dd3ede26391b405c15221e",
-                "sha256:10853a53a4a00417a00913d270dddda75815fcb80675874285f41051c094d7dd",
-                "sha256:1182437cb2d97988cfea04cf6cdc0b0bb9c74f4d56ec3d08b81e23d621a28cc6",
-                "sha256:144921da96c08feb9e2b052c5c5c1d0d151a292c6135623c6b2c041f2a45f9e0",
-                "sha256:1a89ce07ad2d4b8cfc30bd5889ec40613e028ed80ef47da7d9dd2ce969ad30e0",
-                "sha256:1b4c575df7368b3b13e0cebf01d4679f9a28ed2ae6c1cd0b1d5beffb6b2007dc",
-                "sha256:1ccd42229aaac2df431562117ac7e667d702e8e44afdb6cf0e50fa3f18160f0b",
-                "sha256:2645b7d8a738763b664a12a1542c89c940daa55196e8d73e55b169cc5c99f65f",
-                "sha256:288937433bd44e3990e7da2402fabc44a3c6c25d3704da066b85b89a85474ae0",
-                "sha256:34634e196f620c7a61d18d5cf7dc841ca6daa7961aed75d532b7e58b309ac894",
-                "sha256:348174f228b99f33ca1f773e85510e08927620caa59ffe7803b37170df30332b",
-                "sha256:36ac4ddc3d33e852da9cb00ffb08cea62ca05c39711dc67062ca2bb1fae35fd8",
-                "sha256:3713e21ea67bca727eecd4a24bf68bcd414c403faae4989442be60994301ded0",
-                "sha256:389b984139278f97757ea9b08993e7b9d1142912e046ab7d82b3fbaeb0209131",
-                "sha256:426c5ca86415d9b8945c7073597e10de9644802e2ff502b8e1f11a7a2642856b",
-                "sha256:4599a95f9430ae0de82b52ff0d27304fe898c17cb5f4099f7438a51b9998ac77",
-                "sha256:49b7bddc1eebf011ea5ab722fdbe67a401caa34a350d278cc7733c0e88fecb1f",
-                "sha256:53667b5f668991e279d21f94ccfa6e45b4e3f4500e7591ae59a8012d0f010dcb",
-                "sha256:546572a1793cc35857a2ffa1fe0e58571af1779bcc1ffa7c9fb0839885ed69a9",
-                "sha256:583849c743e0e3c9bb7446f5b5addeacedc168d657a69b418063dfdb2d90081c",
-                "sha256:5aee45fd2c6c0f2b9cdddf48c48535e7471e42d6fb81adfde801da0bd5b93241",
-                "sha256:5b193a7e29fd9fa56e502920dca47dffe60f97c863494946bd698c6058a55658",
-                "sha256:5ca74f37f3369b45e1f6b7b06afb182af1fd5dde009e4ffd831830d98cbe5fe7",
-                "sha256:68549c403f79a8e25984376480959975212a670405e3913830614432b5daa07a",
-                "sha256:69f5bc24904d3bc3640961cddd2523e361257ef68585d6e364166dfbe8c78fae",
-                "sha256:6bb85c546591569558571aa1b06aba711b26ae62f111e15e56136d69920e1616",
-                "sha256:6f7b7243850edd0b8b97043f04748f31de50cf426e939def5c16bedb540698f7",
-                "sha256:7001dc9d5f6bb4deb756d5928eaefe1930f6f4179da3924cbd95ee0e9f4dce89",
-                "sha256:7a936f1bb23d370b7c8cc079d5fce4c7d18da87a33c6744e51a93b0f9e97e9b3",
-                "sha256:7c998f2ace8bf76b453b75dbcca500d4f4b9dd3908c13e89b86289b37784848b",
-                "sha256:7cddca31edf8b0653090cbb54562ca027c421c58ddde2c0685f49ff56a1690e0",
-                "sha256:8183dc57ae7d9edc1346e007e840a9f3d6aa7b7f165203a99e16f447150140d2",
-                "sha256:82745b03b4043e04600a6b665cb98697c4339b24e34d74b0a2ac0a2488b6f94d",
-                "sha256:841a94c66577661c1f088ac958cd767d7c9bf507698f45afffe7a4017049de76",
-                "sha256:858e433f12b0e5b3ed2f8da917433b634f4937d0e8793e5cb33c54a1a01df565",
-                "sha256:908a3fa6908716f803b86896a09a2c4dde5f5ce2bb07aacc71ffebb57986ce99",
-                "sha256:9764014ef5e58aab76220c5664abb5d47d5bc858d9debf821e55cfdd0f128485",
-                "sha256:9c7d0a77e36b5f4b01ca398482230ab792061d243d715299b44a0b55c89fe617",
-                "sha256:a5b429eb84339f9f05e06083f119ad814e6d85e27ecbdf9c551dfdbb128eaf8a",
-                "sha256:a66fe406437dd65cacd96a72689a3aaaecaebbcd62d81c5ac1c0fdbeac835096",
-                "sha256:a6b764fb312bd35e47797ad2e63f0d323792837a6ac785a4ca967019357d2bc7",
-                "sha256:b19151e76620a412c2ac1c6f977ab1b9fa7ad43140178345136456d5265b32ed",
-                "sha256:b8438ec5594980d405251451c5b7ea9aa58dda38eb7ac35fb7e4c696712ee24f",
-                "sha256:b8fc3454b4f3bd0a368001d0e968852dad45a873f8b4babd41bc302ec851a099",
-                "sha256:bcb8ebbf2e2c36cfe01a94f2438012c6a9d494cf80f129d9753bcdf33bfc35a6",
-                "sha256:d404dc897ce10e565d647795861762aa2d06ca3f4a728c5e9a835096c7059018",
-                "sha256:d612c976cbc2d17edfcc4c006874b764e85e990c29ce9bd411f926bbfb02b9a2",
-                "sha256:d64177f443594c8697369c10e4bbcac70ef558e0f7921a1de7e4a3d1734bcf67",
-                "sha256:d854b3970067297f3a7fbd7a4683587134aa9b3877ee15aa29eea478dc68f933",
-                "sha256:d8fcccbbc0c13c13702c471da398b8cd72ba740dca5859f148ae8e0e8e0d3e7e",
-                "sha256:e004aa9248e8cb0a5f9b96d003ca7c1c0a5da8decd1066e7b53f59eb8ce7c62b",
-                "sha256:e214d546c8ecb5fc22d6e6011746082abf13a9cf46eefb45769c7b31407c97b5",
-                "sha256:e2d0d88686e3d35a76f3e15a34e8c12d73fc94c1dea1cd55782e695cc14086dd",
-                "sha256:e2f35b4cccd9ed286ad62e0a3c3ac21e06c02abc60e20aa51a3e305a30f5fa79",
-                "sha256:e3070c03701037aa418b55d36532ecb8f8446ed0135acb71c678dbdf12f5b6e4",
-                "sha256:e5e088bf43f6ee6fec7dbf1ef7ff7774a616c236b5c0cb3e00662dd71a56b571",
-                "sha256:e83e3f959aaa1c9df95c22c528096d94848a1bc819f5d0ebf7ee3df0ca63db6c",
-                "sha256:f0dcbc588cd5b725162c076eb9119342f6579c7f7f55057bb7e3c6ff27e13121",
-                "sha256:f27f9da0a7d22b9f981108fd4b62f8b5743423388915a563e651c20d06c1f457",
-                "sha256:f8649a14caa5f8a243628b1d61cf530ad9ae4578814ba726816adb1121fc493e",
-                "sha256:fac0fa4e4f55f118fd87177dacb1c6522fe39c28d498d259014020fec9164c29",
-                "sha256:fd08b90d211c086181caed76931ecfa2bdfc83eea3cfccdb0f82abc6c4b876cb"
+                "sha256:01146546d84185f12721a1d2ce0c6673451a7894d1460b592d378ca4871a0c72",
+                "sha256:059d7151fff513c53a4638da8778be7fce81a0c4854c7348ebd0c4078ddf28fe",
+                "sha256:0c98c59075b890df8abfcc6ad632879540f5791c68baebacb4f833713b510e75",
+                "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5",
+                "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148",
+                "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7",
+                "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e",
+                "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518",
+                "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7",
+                "sha256:32fe6a41ad97302db2931f05bb91abbcc65b5ce4c675cd44b972428dd2947700",
+                "sha256:334edbcff10514ad1d66e3a70b339c0a29886394892490119dbb669627b17717",
+                "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672",
+                "sha256:3ddcb27fb39171de36e207600116ac9dfd4ae46f86c82a9bf3934043e80ebb88",
+                "sha256:42e8804962f9e6f4be2cbaedc0c3718f08f60a16910fa3d86da5a1e3b1bfe60f",
+                "sha256:43d044780732d9e0381ac8d5316f95d7f02ef04d6e4ef6dc82379f09795d993f",
+                "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08",
+                "sha256:46d51518d53edfbe0563662c96954dc8fcace9832332b914375f45a99b77cc9a",
+                "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3",
+                "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b",
+                "sha256:4d4e5a0ceba319942fa6b585cf82539288a61e314ef006c1209f734551ab9536",
+                "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0",
+                "sha256:566df36fd0e901625523a5a1835032f1ebdd7f7886c54584143fa6c668b4df3b",
+                "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a",
+                "sha256:5e61abbec255be7b122aa461021daa7c3f310f3e743411a67079f9b3cc91ece3",
+                "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4",
+                "sha256:62557958002b69699bdb7f5137c6714ca1133f045f97b3903964f47db97ea339",
+                "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158",
+                "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066",
+                "sha256:69469ce8ce7a8df4d37620e3163b71238719e1e2e5048d114a1b6ce0fbf8c662",
+                "sha256:6eb188b84269f357669b62cb576b5b918de10fb7c728a005fa0ebb0b758adce1",
+                "sha256:74ab4ee7794d7ed1b0c37e7333640e0f0a626fc7b398c07a7aef52f484fddde3",
+                "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5",
+                "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01",
+                "sha256:7d6be30b2a75362325176c036d7fb8d19e8846c77e87683ffaa8177b35135613",
+                "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a",
+                "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0",
+                "sha256:88690f4e1f0fbf5339bedbb127e240fec1fd3070e9934c0b7bef83432f779d2f",
+                "sha256:8a97ac839c2c6672c4865e48f3cbad7152cee85f4233fb4ca6291d775b9b954a",
+                "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e",
+                "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2",
+                "sha256:951d4a210744813be63019f3df343bf233b7432aadf0db54c75802247330d3af",
+                "sha256:9ac7a3e245fd0310fd31495eb61af772e637bdf7d88ee81e7f10a3f271bff014",
+                "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33",
+                "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61",
+                "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d",
+                "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187",
+                "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401",
+                "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b",
+                "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d",
+                "sha256:b95b2f470c1b2683febd2e7eab1d3f0e078c91dbdd0b00e9c645d07a413bb99f",
+                "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba",
+                "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977",
+                "sha256:c338ec6ec01c0bc8e735c58b9f5d51e75bacb6ff23296658826d7cfdfdb8678a",
+                "sha256:c5070135e1b7409c4161133aa525419b0062088ed77c92b1da95366ec5cbebbe",
+                "sha256:cc992c6ed024c8c3c592c5fc9846a03dd68a425674900c70122c77ea16c5fb0b",
+                "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f",
+                "sha256:d898cc2c76c135ef65517f4ddd7a3512fb41f23087b0650efb3418b8389a3cd1",
+                "sha256:d99945830a6f3e9638d89a28ed130b1eb24c91255e4f24366fbe699b983f29e4",
+                "sha256:da9b91bca419dc9b9267ffadde24eae9b1a6bffcd09d0a207e5e3af99a03ce0d",
+                "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120",
+                "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750",
+                "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0",
+                "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.48"
+            "version": "==2.0.49"
         },
         "typing-extensions": {
             "hashes": [
@@ -413,11 +537,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:4b314d81163a3e1a169b6a0be2a000a0e204e8873c5de6586f453c55688d422f",
-                "sha256:fb8c01fe6ab13b9b7cdb46892b99b1d66754e1d7ab8e542e865ec13f526b5351"
+                "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50",
+                "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==3.1.7"
+            "version": "==3.1.8"
         }
     },
     "develop": {
@@ -490,146 +614,146 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e",
-                "sha256:0c173ce3a681f309f31b87125fecec7a5d1347261ea11ebbb856fa6006b23c8c",
-                "sha256:0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5",
-                "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815",
-                "sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f",
-                "sha256:150b8ce8e830eb7ccb029ec9ca36022f756986aaaa7956aad6d9ec90089338c0",
-                "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484",
-                "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407",
-                "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6",
-                "sha256:1cf0a70018692f85172348fe06d3a4b63f94ecb055e13a00c644d368eb82e5b8",
-                "sha256:1ed80ff870ca6de33f4d953fda4d55654b9a2b340ff39ab32fa3adbcd718f264",
-                "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815",
-                "sha256:231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2",
-                "sha256:259695e2ccc253feb2a016303543d691825e920917e31f894ca1a687982b1de4",
-                "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579",
-                "sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f",
-                "sha256:2bd9d128ef93637a5d7a6af25363cf5dec3fa21cf80e68055aad627f280e8afa",
-                "sha256:2e1d8ca8611099001949d1cdfaefc510cf0f212484fe7c565f735b68c78c3c95",
-                "sha256:2ef7fedc7a6ecbe99969cd09632516738a97eeb8bd7258bf8a0f23114c057dab",
-                "sha256:2f7fdd9b6e6c529d6a2501a2d36b240109e78a8ceaef5687cfcfa2bbe671d297",
-                "sha256:30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a",
-                "sha256:31215157227939b4fb3d740cd23fe27be0439afef67b785a1eb78a3ae69cba9e",
-                "sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84",
-                "sha256:3516bbb8d42169de9e61b8520cbeeeb716f12f4ecfe3fd30a9919aa16c806ca8",
-                "sha256:3778fd7d7cd04ae8f54651f4a7a0bd6e39a0cf20f801720a4c21d80e9b7ad6b0",
-                "sha256:39f5068d35621da2881271e5c3205125cc456f54e9030d3f723288c873a71bf9",
-                "sha256:404a1e552cf5b675a87f0651f8b79f5f1e6fd100ee88dc612f89aa16abd4486f",
-                "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1",
-                "sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843",
-                "sha256:4482481cb0572180b6fd976a4d5c72a30263e98564da68b86ec91f0fe35e8565",
-                "sha256:461598cd852bfa5a61b09cae2b1c02e2efcd166ee5516e243d540ac24bfa68a7",
-                "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c",
-                "sha256:48696db7f18afb80a068821504296eb0787d9ce239b91ca15059d1d3eaacf13b",
-                "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7",
-                "sha256:4d1d02209e06550bdaef34af58e041ad71b88e624f5d825519da3a3308e22687",
-                "sha256:4f41da960b196ea355357285ad1316a00099f22d0929fe168343b99b254729c9",
-                "sha256:517ad0e93394ac532745129ceabdf2696b609ec9f87863d337140317ebce1c14",
-                "sha256:51fb3c322c81d20567019778cb5a4a6f2dc1c200b886bc0d636238e364848c89",
-                "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f",
-                "sha256:530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0",
-                "sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9",
-                "sha256:54fae94be3d75f3e573c9a1b5402dc593de19377013c9a0e4285e3d402dd3a2a",
-                "sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389",
-                "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0",
-                "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30",
-                "sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd",
-                "sha256:5feb91325bbceade6afab43eb3b508c63ee53579fe896c77137ded51c6b6958e",
-                "sha256:60c74963d8350241a79cb8feea80e54d518f72c26db618862a8f53e5023deaf9",
-                "sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc",
-                "sha256:659a1e1b500fac8f2779dd9e1570464e012f43e580371470b45277a27baa7532",
-                "sha256:695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d",
-                "sha256:69dd852c2f0ad631b8b60cfbe25a28c0058a894de5abb566619c205ce0550eae",
-                "sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2",
-                "sha256:71be7e0e01753a89cf024abf7ecb6bca2c81738ead80d43004d9b5e3f1244e64",
-                "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f",
-                "sha256:74a2e659c7ecbc73562e2a15e05039f1e22c75b7c7618b4b574a3ea9118d1557",
-                "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e",
-                "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff",
-                "sha256:7a6967aaf043bceabab5412ed6bd6bd26603dae84d5cb75bf8d9a74a4959d398",
-                "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db",
-                "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a",
-                "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43",
-                "sha256:802168e03fba8bbc5ce0d866d589e4b1ca751d06edee69f7f3a19c5a9fe6b597",
-                "sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c",
-                "sha256:82060f995ab5003a2d6e0f4ad29065b7672b6593c8c63559beefe5b443242c3e",
-                "sha256:836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2",
-                "sha256:8761ac29b6c81574724322a554605608a9960769ea83d2c73e396f3df896ad54",
-                "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e",
-                "sha256:899d28f422116b08be5118ef350c292b36fc15ec2daeb9ea987c89281c7bb5c4",
-                "sha256:8bc5f0687d796c05b1e28ab0d38a50e6309906ee09375dd3aff6a9c09dd6e8f4",
-                "sha256:8bea55c4eef25b0b19a0337dc4e3f9a15b00d569c77211fa8cde38684f234fb7",
-                "sha256:8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6",
-                "sha256:90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5",
-                "sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194",
-                "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69",
-                "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f",
-                "sha256:97d0235baafca5f2b09cf332cc275f021e694e8362c6bb9c96fc9a0eb74fc316",
-                "sha256:9ca4c0b502ab399ef89248a2c84c54954f77a070f28e546a85e91da627d1301e",
-                "sha256:9cc4fc6c196d6a8b76629a70ddfcd4635a6898756e2d9cac5565cf0654605d73",
-                "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8",
-                "sha256:a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923",
-                "sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88",
-                "sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f",
-                "sha256:a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21",
-                "sha256:a9e68c9d88823b274cf1e72f28cb5dc89c990edf430b0bfd3e2fb0785bfeabf4",
-                "sha256:aa9cccf4a44b9b62d8ba8b4dd06c649ba683e4bf04eea606d2e94cfc2d6ff4d6",
-                "sha256:ab30e5e3e706e3063bc6de96b118688cb10396b70bb9864a430f67df98c61ecc",
-                "sha256:ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2",
-                "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866",
-                "sha256:b35b200d6a71b9839a46b9b7fff66b6638bb52fc9658aa58796b0326595d3021",
-                "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2",
-                "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d",
-                "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8",
-                "sha256:bc72863f4d9aba2e8fd9085e63548a324ba706d2ea2c83b260da08a59b9482de",
-                "sha256:bf625105bb9eef28a56a943fec8c8a98aeb80e7d7db99bd3c388137e6eb2d237",
-                "sha256:c2274ca724536f173122f36c98ce188fd24ce3dad886ec2b7af859518ce008a4",
-                "sha256:c45a03a4c69820a399f1dda9e1d8fbf3562eda46e7720458180302021b08f778",
-                "sha256:c8ae56368f8cc97c7e40a7ee18e1cedaf8e780cd8bc5ed5ac8b81f238614facb",
-                "sha256:c907cdc8109f6c619e6254212e794d6548373cc40e1ec75e6e3823d9135d29cc",
-                "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602",
-                "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4",
-                "sha256:d08ec48f0a1c48d75d0356cea971921848fb620fdeba805b28f937e90691209f",
-                "sha256:d1a2ee9c1499fc8f86f4521f27a973c914b211ffa87322f4ee33bb35392da2c5",
-                "sha256:d5f5d1e9def3405f60e3ca8232d56f35c98fb7bf581efcc60051ebf53cb8b611",
-                "sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8",
-                "sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf",
-                "sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d",
-                "sha256:dad6e0f2e481fffdcf776d10ebee25e0ef89f16d691f1e5dee4b586375fdc64b",
-                "sha256:dda86aba335c902b6149a02a55b38e96287157e609200811837678214ba2b1db",
-                "sha256:df01808ee470038c3f8dc4f48620df7225c49c2d6639e38f96e6d6ac6e6f7b0e",
-                "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077",
-                "sha256:e25369dc110d58ddf29b949377a93e0716d72a24f62bad72b2b39f155949c1fd",
-                "sha256:e3c701e954abf6fc03a49f7c579cc80c2c6cc52525340ca3186c41d3f33482ef",
-                "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e",
-                "sha256:e68c14b04827dd76dcbd1aeea9e604e3e4b78322d8faf2f8132c7138efa340a8",
-                "sha256:e8aeb10fcbe92767f0fa69ad5a72deca50d0dca07fbde97848997d778a50c9fe",
-                "sha256:e985a16ff513596f217cee86c21371b8cd011c0f6f056d0920aa2d926c544058",
-                "sha256:ecbbd45615a6885fe3240eb9db73b9e62518b611850fdf8ab08bd56de7ad2b17",
-                "sha256:ee4ec14bc1680d6b0afab9aea2ef27e26d2024f18b24a2d7155a52b60da7e833",
-                "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421",
-                "sha256:f0cdaecd4c953bfae0b6bb64910aaaca5a424ad9c72d85cb88417bb9814f7550",
-                "sha256:f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff",
-                "sha256:f50498891691e0864dc3da965f340fada0771f6142a378083dc4608f4ea513e2",
-                "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc",
-                "sha256:f61aa92e4aad0be58eb6eb4e0c21acf32cf8065f4b2cae5665da756c4ceef982",
-                "sha256:f6e4333fb15c83f7d1482a76d45a0818897b3d33f00efd215528ff7c51b8e35d",
-                "sha256:f820f24b09e3e779fe84c3c456cb4108a7aa639b0d1f02c28046e11bfcd088ed",
-                "sha256:f98059e4fcd3e3e4e2d632b7cf81c2faae96c43c60b569e9c621468082f1d104",
-                "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659"
+                "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc",
+                "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c",
+                "sha256:07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67",
+                "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4",
+                "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0",
+                "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c",
+                "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5",
+                "sha256:12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444",
+                "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153",
+                "sha256:14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9",
+                "sha256:16d971e29578a5e97d7117866d15889a4a07befe0e87e703ed63cd90cb348c01",
+                "sha256:177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217",
+                "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b",
+                "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c",
+                "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a",
+                "sha256:1dc8b0ea451d6e69735094606991f32867807881400f808a106ee1d963c46a83",
+                "sha256:1efde3cae86c8c273f1eb3b287be7d8499420cf2fe7585c41d370d3e790054a5",
+                "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7",
+                "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb",
+                "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c",
+                "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1",
+                "sha256:2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42",
+                "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab",
+                "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df",
+                "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e",
+                "sha256:320ade88cfb846b8cd6b4ddf5ee9e80ee0c1f52401f2456b84ae1ae6a1a5f207",
+                "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18",
+                "sha256:36836d6ff945a00b88ba1e4572d721e60b5b8c98c155d465f56ad19d68f23734",
+                "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38",
+                "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110",
+                "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18",
+                "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44",
+                "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d",
+                "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48",
+                "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e",
+                "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5",
+                "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d",
+                "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53",
+                "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790",
+                "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c",
+                "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b",
+                "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116",
+                "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d",
+                "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10",
+                "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6",
+                "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2",
+                "sha256:6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776",
+                "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a",
+                "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265",
+                "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008",
+                "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943",
+                "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374",
+                "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246",
+                "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e",
+                "sha256:6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5",
+                "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616",
+                "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15",
+                "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41",
+                "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960",
+                "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752",
+                "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e",
+                "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72",
+                "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7",
+                "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8",
+                "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b",
+                "sha256:813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4",
+                "sha256:82b271f5137d07749f7bf32f70b17ab6eaabedd297e75dce75081a24f76eb545",
+                "sha256:84c018e49c3bf790f9c2771c45e9313a08c2c2a6342b162cd650258b57817706",
+                "sha256:8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366",
+                "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb",
+                "sha256:87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a",
+                "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e",
+                "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00",
+                "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f",
+                "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a",
+                "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1",
+                "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66",
+                "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356",
+                "sha256:a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319",
+                "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4",
+                "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad",
+                "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d",
+                "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5",
+                "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7",
+                "sha256:aef65cd602a6d0e0ff6f9930fcb1c8fec60dd2cfcb6facaf4bdb0e5873042db0",
+                "sha256:af21eb4409a119e365397b2adbaca4c9ccab56543a65d5dbd9f920d6ac29f686",
+                "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34",
+                "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49",
+                "sha256:bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c",
+                "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1",
+                "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e",
+                "sha256:bd9b23791fe793e4968dba0c447e12f78e425c59fc0e3b97f6450f4781f3ee60",
+                "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0",
+                "sha256:c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274",
+                "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d",
+                "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0",
+                "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae",
+                "sha256:c593052c465475e64bbfe5dbd81680f64a67fdc752c56d7a0ae205dc8aeefe0f",
+                "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d",
+                "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe",
+                "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3",
+                "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393",
+                "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1",
+                "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af",
+                "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44",
+                "sha256:d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00",
+                "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c",
+                "sha256:dca4bbc466a95ba9c0234ef56d7dd9509f63da22274589ebd4ed7f1f4d4c54e3",
+                "sha256:dd915403e231e6b1809fe9b6d9fc55cf8fb5e02765ac625d9cd623342a7905d7",
+                "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd",
+                "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e",
+                "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b",
+                "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8",
+                "sha256:e5f4d355f0a2b1a31bc3edec6795b46324349c9cb25eed068049e4f472fb4259",
+                "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859",
+                "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46",
+                "sha256:e80c8378d8f3d83cd3164da1ad2df9e37a666cdde7b1cb2298ed0b558064be30",
+                "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b",
+                "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46",
+                "sha256:ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24",
+                "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a",
+                "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24",
+                "sha256:f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc",
+                "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215",
+                "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063",
+                "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832",
+                "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6",
+                "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79",
+                "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.4.6"
+            "version": "==3.4.7"
         },
         "click": {
             "hashes": [
-                "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a",
-                "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"
+                "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5",
+                "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.3.1"
+            "version": "==8.3.2"
         },
         "colorama": {
             "hashes": [
@@ -805,11 +929,11 @@
         },
         "faker": {
             "hashes": [
-                "sha256:58b5a9054c367bd5fb2e948634105364cc570e78a98a8e5161a74691c45f158f",
-                "sha256:6238a4058a8b581892e3d78fe5fdfa7568739e1c8283e4ede83f1dde0bfc1a3b"
+                "sha256:20f3a6ec8c266b74d4c554e34118b21c3c2056c0b4a519d15c8decb3a4e6e795",
+                "sha256:71ab3c3370da9d2205ab74ffb0fd51273063ad562b3a3bb69d0026a20923e318"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==40.12.0"
+            "version": "==40.15.0"
         },
         "flake8": {
             "hashes": [
@@ -847,11 +971,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea",
-                "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"
+                "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67",
+                "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.11"
+            "version": "==3.12"
         },
         "iniconfig": {
             "hashes": [
@@ -1063,11 +1187,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4",
-                "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
+                "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f",
+                "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==26.0"
+            "version": "==26.1"
         },
         "parse": {
             "hashes": [
@@ -1102,11 +1226,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934",
-                "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868"
+                "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a",
+                "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.9.4"
+            "version": "==4.9.6"
         },
         "pluggy": {
             "hashes": [
@@ -1160,12 +1284,12 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b",
-                "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11"
+                "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9",
+                "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.10'",
-            "version": "==9.0.2"
+            "version": "==9.0.3"
         },
         "pytest-cov": {
             "hashes": [
@@ -1254,11 +1378,11 @@
         },
         "rich": {
             "hashes": [
-                "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d",
-                "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b"
+                "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb",
+                "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"
             ],
-            "markers": "python_full_version >= '3.8.0'",
-            "version": "==14.3.3"
+            "markers": "python_full_version >= '3.9.0'",
+            "version": "==15.0.0"
         },
         "selenium": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -43,27 +43,32 @@ make test
 
 ## API Endpoints
 
-Base resource: `/wishlists`
+Browser UI: `/`
+
+Swagger UI: `/apidocs/`
+
+Base resource: `/api/wishlists`
 
 ### Wishlists
 
 | Method | Path | Description |
 |---|---|---|
-| GET | `/wishlists` | List wishlists |
-| POST | `/wishlists` | Create a wishlist |
-| GET | `/wishlists/{wishlist_id}` | Get one wishlist |
-| PUT | `/wishlists/{wishlist_id}` | Update wishlist name/description |
-| DELETE | `/wishlists/{wishlist_id}` | Delete a wishlist |
+| GET | `/api/wishlists` | List wishlists |
+| POST | `/api/wishlists` | Create a wishlist |
+| GET | `/api/wishlists/{wishlist_id}` | Get one wishlist |
+| PUT | `/api/wishlists/{wishlist_id}` | Update wishlist name/description |
+| DELETE | `/api/wishlists/{wishlist_id}` | Delete a wishlist |
+| POST | `/api/wishlists/{wishlist_id}/private` | Set a wishlist to private |
 
 ### Wishlist Items
 
 | Method | Path | Description |
 |---|---|---|
-| GET | `/wishlists/{wishlist_id}/items` | List items in a wishlist |
-| POST | `/wishlists/{wishlist_id}/items` | Create an item in a wishlist |
-| GET | `/wishlists/{wishlist_id}/items/{item_id}` | Get one item in a wishlist |
-| PUT | `/wishlists/{wishlist_id}/items/{item_id}` | Update item in wishlist |
-| DELETE | `/wishlists/{wishlist_id}/items/{item_id}` | Deletes item in a wishlist |
+| GET | `/api/wishlists/{wishlist_id}/items` | List items in a wishlist |
+| POST | `/api/wishlists/{wishlist_id}/items` | Create an item in a wishlist |
+| GET | `/api/wishlists/{wishlist_id}/items/{item_id}` | Get one item in a wishlist |
+| PUT | `/api/wishlists/{wishlist_id}/items/{item_id}` | Update item in wishlist |
+| DELETE | `/api/wishlists/{wishlist_id}/items/{item_id}` | Deletes item in a wishlist |
 
 ## Project Layout
 

--- a/features/steps/wishlist_steps.py
+++ b/features/steps/wishlist_steps.py
@@ -10,6 +10,7 @@ HTTP_200_OK = 200
 HTTP_204_NO_CONTENT = 204
 HTTP_201_CREATED = 201
 WAIT_TIMEOUT = 30
+API_BASE_PATH = "/api/wishlists"
 
 
 @given("the Wishlist service is running")
@@ -38,7 +39,7 @@ def step_should_see_text(context, text):
 @given("no wishlists exist")
 def step_no_wishlists_exist(context):
     """Delete all wishlists so each scenario starts from a clean state."""
-    rest_endpoint = f"{context.base_url}/wishlists"
+    rest_endpoint = f"{context.base_url}{API_BASE_PATH}"
     context.resp = requests.get(rest_endpoint, timeout=WAIT_TIMEOUT)
     assert context.resp.status_code == HTTP_200_OK
 
@@ -57,7 +58,7 @@ def create_wishlist_via_api(context, name, customer_id, description):
         "description": description,
     }
     create_resp = requests.post(
-        f"{context.base_url}/wishlists",
+        f"{context.base_url}{API_BASE_PATH}",
         json=payload,
         timeout=WAIT_TIMEOUT,
     )
@@ -229,7 +230,7 @@ def step_wishlist_name_updated(context, name):
     assert name in table_text
 
     response = requests.get(
-        f"{context.base_url}/wishlists/{context.wishlist['id']}",
+        f"{context.base_url}{API_BASE_PATH}/{context.wishlist['id']}",
         timeout=WAIT_TIMEOUT,
     )
     assert response.status_code == HTTP_200_OK
@@ -251,7 +252,7 @@ def step_wishlist_description_updated(context, description):
     assert description in table_text
 
     response = requests.get(
-        f"{context.base_url}/wishlists/{context.wishlist['id']}",
+        f"{context.base_url}{API_BASE_PATH}/{context.wishlist['id']}",
         timeout=WAIT_TIMEOUT,
     )
     assert response.status_code == HTTP_200_OK

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -32,6 +32,7 @@ def create_app():
     # Create Flask application
     app = Flask(__name__)
     app.config.from_object(config)
+    app.url_map.strict_slashes = False
 
     # Initialize Plugins
     # pylint: disable=import-outside-toplevel

--- a/service/routes.py
+++ b/service/routes.py
@@ -15,69 +15,229 @@
 ######################################################################
 
 """
-Wishlist Service
-
-This service implements a REST API that allows you to Create, Read, Update
-and Delete Wishlist
+Wishlist Service with Flask-RESTX and Swagger
 """
 
-from flask import jsonify, request, url_for, abort
+from flask import jsonify, request
 from flask import current_app as app  # Import Flask application
-from service.models import Wishlist, Item
+from flask_restx import Api, Resource, fields
+from werkzeug.exceptions import HTTPException
+from service.models import Wishlist, Item, DataValidationError
 from service.common import status  # HTTP Status Codes
+
+ERROR_TITLES = {
+    status.HTTP_400_BAD_REQUEST: "Bad Request",
+    status.HTTP_404_NOT_FOUND: "Not Found",
+    status.HTTP_405_METHOD_NOT_ALLOWED: "Method not Allowed",
+    status.HTTP_409_CONFLICT: "Conflict",
+    status.HTTP_415_UNSUPPORTED_MEDIA_TYPE: "Unsupported media type",
+    status.HTTP_500_INTERNAL_SERVER_ERROR: "Internal Server Error",
+}
+
+######################################################################
+# Configure Swagger before initializing it
+######################################################################
+api = Api(
+    app,
+    version="1.0.0",
+    title="Wishlist REST API Service",
+    description="Manage wishlists and wishlist items.",
+    default="wishlists",
+    default_label="Wishlist operations",
+    doc="/apidocs/",
+    prefix="/api",
+)
+
+create_wishlist_model = api.model(
+    "WishlistCreate",
+    {
+        "name": fields.String(required=True, description="The wishlist name"),
+        "customer_id": fields.Integer(required=True, description="The owning customer id"),
+        "description": fields.String(required=False, description="Optional wishlist description"),
+    },
+)
+
+update_wishlist_model = api.model(
+    "WishlistUpdate",
+    {
+        "name": fields.String(required=True, description="The updated wishlist name"),
+        "description": fields.String(required=False, description="The updated wishlist description"),
+    },
+)
+
+create_item_model = api.model(
+    "ItemCreate",
+    {
+        "product_id": fields.String(required=True, description="The product identifier"),
+        "product_name": fields.String(required=True, description="The product name"),
+        "quantity": fields.Integer(required=False, description="The desired quantity", default=1),
+        "variant_id": fields.String(required=True, description="The product variant identifier"),
+    },
+)
+
+item_model = api.inherit(
+    "Item",
+    create_item_model,
+    {
+        "id": fields.Integer(readOnly=True, description="The unique item identifier"),
+        "wishlist_id": fields.Integer(readOnly=True, description="The parent wishlist identifier"),
+        "added_at": fields.String(readOnly=True, description="The item creation timestamp"),
+        "updated_at": fields.String(readOnly=True, description="The item update timestamp"),
+    },
+)
+
+wishlist_model = api.inherit(
+    "Wishlist",
+    create_wishlist_model,
+    {
+        "id": fields.Integer(readOnly=True, description="The unique wishlist identifier"),
+        "is_private": fields.Boolean(readOnly=True, description="Whether the wishlist is private"),
+        "created_at": fields.String(readOnly=True, description="The wishlist creation timestamp"),
+        "updated_at": fields.String(readOnly=True, description="The wishlist update timestamp"),
+        "items": fields.List(fields.Nested(item_model), readOnly=True, description="Wishlist items"),
+    },
+)
+
+health_model = api.model(
+    "HealthStatus",
+    {
+        "status": fields.String(required=True, description="The service health state"),
+    },
+)
+
+
+def api_error_response(status_code, message, error_title=None, **kwargs):
+    """Build a standard JSON error response."""
+    payload = {
+        "status": status_code,
+        "error": error_title or ERROR_TITLES.get(status_code, "Error"),
+        "message": message,
+    }
+    payload.update(kwargs)
+    return payload, status_code
+
+
+@api.errorhandler(DataValidationError)
+def request_validation_error(error):
+    """Handles validation errors from bad data on API routes."""
+    message = str(error)
+    app.logger.warning(message)
+    return api_error_response(status.HTTP_400_BAD_REQUEST, message)
+
+
+@api.errorhandler(HTTPException)
+def http_exception_handler(error):
+    """Handles HTTP errors for API routes."""
+    status_code = getattr(error, "code", status.HTTP_500_INTERNAL_SERVER_ERROR)
+    data = dict(getattr(error, "data", {}) or {})
+    message = data.pop("message", None) or getattr(error, "description", str(error))
+    error_title = data.pop("error", ERROR_TITLES.get(status_code, "Error"))
+    status_value = data.pop("status", status_code)
+    app.logger.warning(message)
+    return api_error_response(status_value, message, error_title, **data)
+
+
+@api.errorhandler(Exception)
+def default_error_handler(error):
+    """Handles unexpected errors for API routes."""
+    message = str(error) or ERROR_TITLES[status.HTTP_500_INTERNAL_SERVER_ERROR]
+    app.logger.error(message)
+    return api_error_response(status.HTTP_500_INTERNAL_SERVER_ERROR, message)
+
+
+def api_url(path):
+    """Build an absolute API URL for the current request."""
+    return f"{request.url_root.rstrip('/')}{path}"
+
+
+def abort(error_code, message, **kwargs):
+    """Logs errors before aborting."""
+    app.logger.error(message)
+    api.abort(
+        error_code,
+        message=message,
+        error=ERROR_TITLES.get(error_code, "Error"),
+        status=error_code,
+        **kwargs,
+    )
 
 
 ######################################################################
 # GET INDEX
 ######################################################################
 def _index_json():
-    return jsonify(
-        name="Wishlist REST API Service",
-        version="1.0",
-        message="Wishlist service is up",
-        paths=url_for("list_wishlists", _external=True),
-        endpoints={
-            "Service": [
-                {"method": "GET", "path": "/health", "description": "Health check"},
-            ],
-            "Wishlists": [
-                {
-                    "method": "GET",
-                    "path": "/wishlists",
-                    "description": "List wishlists (supports ?customer_id=, ?name=, ?description=)",
-                },
-                {"method": "POST", "path": "/wishlists", "description": "Create a wishlist"},
-                {"method": "GET", "path": "/wishlists/{wishlist_id}", "description": "Get one wishlist"},
-                {"method": "PUT", "path": "/wishlists/{wishlist_id}", "description": "Update wishlist name/description"},
-                {"method": "DELETE", "path": "/wishlists/{wishlist_id}", "description": "Delete a wishlist"},
-                {
-                    "method": "POST",
-                    "path": "/wishlists/{wishlist_id}/private",
-                    "description": "Action: set wishlist privacy to private",
-                },
-            ],
-            "Wishlist Items": [
-                {
-                    "method": "GET",
-                    "path": "/wishlists/{wishlist_id}/items",
-                    "description": "List items in a wishlist (supports ?product_name=)",
-                },
-                {"method": "POST", "path": "/wishlists/{wishlist_id}/items",
-                 "description": "Create an item in a wishlist"},
-                {"method": "GET", "path": "/wishlists/{wishlist_id}/items/{item_id}",
-                 "description": "Get one item in a wishlist"},
-                {"method": "PUT", "path": "/wishlists/{wishlist_id}/items/{item_id}",
-                 "description": "Update item in wishlist"},
-                {"method": "DELETE", "path": "/wishlists/{wishlist_id}/items/{item_id}",
-                 "description": "Delete item from wishlist"},
-            ],
-        },
-    ), status.HTTP_200_OK
+    return (
+        jsonify(
+            name="Wishlist REST API Service",
+            version="1.0",
+            message="Wishlist service is up",
+            paths=api_url("/api/wishlists"),
+            docs=api_url("/apidocs/"),
+            endpoints={
+                "Service": [
+                    {"method": "GET", "path": "/api/health", "description": "Health check"},
+                    {"method": "GET", "path": "/apidocs/", "description": "Swagger UI"},
+                ],
+                "Wishlists": [
+                    {
+                        "method": "GET",
+                        "path": "/api/wishlists",
+                        "description": "List wishlists (supports ?customer_id=, ?name=, ?description=)",
+                    },
+                    {"method": "POST", "path": "/api/wishlists", "description": "Create a wishlist"},
+                    {"method": "GET", "path": "/api/wishlists/{wishlist_id}", "description": "Get one wishlist"},
+                    {
+                        "method": "PUT",
+                        "path": "/api/wishlists/{wishlist_id}",
+                        "description": "Update wishlist name/description",
+                    },
+                    {
+                        "method": "DELETE",
+                        "path": "/api/wishlists/{wishlist_id}",
+                        "description": "Delete a wishlist",
+                    },
+                    {
+                        "method": "POST",
+                        "path": "/api/wishlists/{wishlist_id}/private",
+                        "description": "Action: set wishlist privacy to private",
+                    },
+                ],
+                "Wishlist Items": [
+                    {
+                        "method": "GET",
+                        "path": "/api/wishlists/{wishlist_id}/items",
+                        "description": "List items in a wishlist (supports ?product_name=)",
+                    },
+                    {
+                        "method": "POST",
+                        "path": "/api/wishlists/{wishlist_id}/items",
+                        "description": "Create an item in a wishlist",
+                    },
+                    {
+                        "method": "GET",
+                        "path": "/api/wishlists/{wishlist_id}/items/{item_id}",
+                        "description": "Get one item in a wishlist",
+                    },
+                    {
+                        "method": "PUT",
+                        "path": "/api/wishlists/{wishlist_id}/items/{item_id}",
+                        "description": "Update item in wishlist",
+                    },
+                    {
+                        "method": "DELETE",
+                        "path": "/api/wishlists/{wishlist_id}/items/{item_id}",
+                        "description": "Delete item from wishlist",
+                    },
+                ],
+            },
+        ),
+        status.HTTP_200_OK,
+    )
 
 
 @app.route("/")
 def index():
-    """Root URL response – HTML landing page or JSON for API clients"""
+    """Root URL response - HTML landing page or JSON for API clients."""
     app.logger.info("Request for Root URL")
     if "application/json" in request.headers.get("Accept", ""):
         return _index_json()
@@ -86,7 +246,7 @@ def index():
 
 @app.route("/health", methods=["GET"])
 def healthcheck():
-    """Health endpoint for liveness and readiness probes"""
+    """Health endpoint for liveness and readiness probes."""
     return jsonify({"status": "OK"}), status.HTTP_200_OK
 
 
@@ -98,9 +258,8 @@ def healthcheck():
 ######################################################################
 # LIST ALL WISHLISTS
 ######################################################################
-@app.route("/wishlists", methods=["GET"])
 def list_wishlists():
-    """Returns all of the Wishlists, optionally filtered by query params"""
+    """Returns all of the Wishlists, optionally filtered by query params."""
     app.logger.info("Request for wishlist list")
 
     wishlists = []
@@ -112,8 +271,8 @@ def list_wishlists():
         app.logger.info("Filtering by customer_id: %s", customer_id)
         try:
             customer_id = int(customer_id)
-        except ValueError:
-            abort(status.HTTP_400_BAD_REQUEST, f"Invalid customer_id: {customer_id}")
+        except ValueError as error:
+            raise DataValidationError(f"Invalid customer_id: {customer_id}") from error
         wishlists = Wishlist.find_by_customer_id(customer_id)
     elif name:
         app.logger.info("Filtering by name: %s", name)
@@ -127,28 +286,26 @@ def list_wishlists():
 
     results = [wishlist.serialize() for wishlist in wishlists]
     app.logger.info("Returning %d wishlists", len(results))
-    return jsonify(results), status.HTTP_200_OK
+    return results, status.HTTP_200_OK
 
 
 ######################################################################
 # READ A WISHLIST
 ######################################################################
-@app.route("/wishlists/<int:wishlist_id>", methods=["GET"])
 def get_wishlist(wishlist_id):
-    """Retrieve a single Wishlist by its ID"""
+    """Retrieve a single Wishlist by its ID."""
     app.logger.info("Request to Retrieve a wishlist with id [%s]", wishlist_id)
 
     wishlist = Wishlist.find(wishlist_id)
     if not wishlist:
         abort(status.HTTP_404_NOT_FOUND, f"Wishlist with id '{wishlist_id}' not found.")
 
-    return jsonify(wishlist.serialize()), status.HTTP_200_OK
+    return wishlist.serialize(), status.HTTP_200_OK
 
 
 ######################################################################
 # ACTION: SET WISHLIST TO PRIVATE
 ######################################################################
-@app.route("/wishlists/<int:wishlist_id>/private", methods=["POST"])
 def set_wishlist_private(wishlist_id):
     """Action: mark a wishlist as private (not a generic CRUD update)."""
     app.logger.info("Request to set wishlist id [%s] to private", wishlist_id)
@@ -160,15 +317,14 @@ def set_wishlist_private(wishlist_id):
         )
     wishlist.is_private = True
     wishlist.update()
-    return jsonify(wishlist.serialize()), status.HTTP_200_OK
+    return wishlist.serialize(), status.HTTP_200_OK
 
 
 ######################################################################
 # LIST ITEMS IN A WISHLIST
 ######################################################################
-@app.route("/wishlists/<int:wishlist_id>/items", methods=["GET"])
 def list_wishlist_items(wishlist_id):
-    """List all items belonging to a specific Wishlist"""
+    """List all items belonging to a specific Wishlist."""
     app.logger.info("Request to list items for wishlist id [%s]", wishlist_id)
 
     wishlist = Wishlist.find(wishlist_id)
@@ -183,15 +339,14 @@ def list_wishlist_items(wishlist_id):
         items = wishlist.items
 
     results = [item.serialize() for item in items]
-    return jsonify(results), status.HTTP_200_OK
+    return results, status.HTTP_200_OK
 
 
 ######################################################################
 # READ AN ITEM IN A WISHLIST
 ######################################################################
-@app.route("/wishlists/<int:wishlist_id>/items/<int:item_id>", methods=["GET"])
 def get_wishlist_item(wishlist_id, item_id):
-    """Retrieve a single Item from a Wishlist by its ID"""
+    """Retrieve a single Item from a Wishlist by its ID."""
     app.logger.info(
         "Request to Retrieve item %s from wishlist %s", item_id, wishlist_id
     )
@@ -205,13 +360,12 @@ def get_wishlist_item(wishlist_id, item_id):
         abort(status.HTTP_404_NOT_FOUND, f"Item with id '{item_id}' not found.")
 
     app.logger.info("Returning item: %s", item.product_name)
-    return jsonify(item.serialize()), status.HTTP_200_OK
+    return item.serialize(), status.HTTP_200_OK
 
 
 ######################################################################
 # CREATE ITEM IN A WISHLIST
 ######################################################################
-@app.route("/wishlists/<int:wishlist_id>/items", methods=["POST"])
 def create_wishlist_items(wishlist_id):
     """
     Create an Item in a Wishlist
@@ -225,11 +379,10 @@ def create_wishlist_items(wishlist_id):
 
     check_content_type("application/json")
 
-    data = request.get_json()
+    data = request.get_json() or {}
     data["wishlist_id"] = wishlist_id
     app.logger.info("Processing: %s", data)
 
-    # Check for duplicate (wishlist_id, product_id, variant_id)
     existing = Item.find_by_wishlist_product_variant(
         wishlist_id, data.get("product_id"), data.get("variant_id")
     )
@@ -246,11 +399,9 @@ def create_wishlist_items(wishlist_id):
     item.create()
     app.logger.info("Item with new id [%s] saved!", item.id)
 
-    location_url = (
-        f"{request.url_root.rstrip('/')}/wishlists/{wishlist_id}/items/{item.id}"
-    )
+    location_url = f"{request.url_root.rstrip('/')}/api/wishlists/{wishlist_id}/items/{item.id}"
     return (
-        jsonify(item.serialize()),
+        item.serialize(),
         status.HTTP_201_CREATED,
         {"Location": location_url},
     )
@@ -259,7 +410,6 @@ def create_wishlist_items(wishlist_id):
 ######################################################################
 # UPDATE AN ITEM IN A WISHLIST
 ######################################################################
-@app.route("/wishlists/<int:wishlist_id>/items/<int:item_id>", methods=["PUT"])
 def update_wishlist_item(wishlist_id, item_id):
     """
     Update an Item in a Wishlist
@@ -286,20 +436,19 @@ def update_wishlist_item(wishlist_id, item_id):
 
     check_content_type("application/json")
 
-    data = request.get_json()
+    data = request.get_json() or {}
     data["wishlist_id"] = wishlist_id
     app.logger.info("Processing: %s", data)
     item.deserialize(data)
     item.update()
 
     app.logger.info("Item with id [%s] updated.", item.id)
-    return jsonify(item.serialize()), status.HTTP_200_OK
+    return item.serialize(), status.HTTP_200_OK
 
 
 ######################################################################
 # CREATE A NEW WISHLIST
 ######################################################################
-@app.route("/wishlists", methods=["POST"])
 def create_wishlists():
     """
     Create a Wishlist
@@ -309,16 +458,16 @@ def create_wishlists():
     check_content_type("application/json")
 
     wishlist = Wishlist()
-    data = request.get_json()
+    data = request.get_json() or {}
     app.logger.info("Processing: %s", data)
     wishlist.deserialize(data)
 
     wishlist.create()
     app.logger.info("Wishlist with new id [%s] saved!", wishlist.id)
 
-    location_url = f"{request.url_root.rstrip('/')}/wishlists/{wishlist.id}"
+    location_url = f"{request.url_root.rstrip('/')}/api/wishlists/{wishlist.id}"
     return (
-        jsonify(wishlist.serialize()),
+        wishlist.serialize(),
         status.HTTP_201_CREATED,
         {"Location": location_url},
     )
@@ -327,7 +476,6 @@ def create_wishlists():
 ######################################################################
 # DELETE A WISHLIST
 ######################################################################
-@app.route("/wishlists/<int:wishlist_id>", methods=["DELETE"])
 def delete_wishlists(wishlist_id):
     """
     Delete a Wishlist
@@ -336,20 +484,18 @@ def delete_wishlists(wishlist_id):
     """
     app.logger.info("Request to Delete a wishlist with id [%s]", wishlist_id)
 
-    # Delete the Wishlist if it exists
     wishlist = Wishlist.find(wishlist_id)
     if wishlist:
         app.logger.info("Wishlist with ID: %d found.", wishlist.id)
         wishlist.delete()
 
     app.logger.info("Wishlist with ID: %d delete complete.", wishlist_id)
-    return {}, status.HTTP_204_NO_CONTENT
+    return "", status.HTTP_204_NO_CONTENT
 
 
 ######################################################################
 # DELETE AN ITEM FROM A WISHLIST
 ######################################################################
-@app.route("/wishlists/<int:wishlist_id>/items/<int:item_id>", methods=["DELETE"])
 def delete_wishlist_item(wishlist_id, item_id):
     """
     Delete an Item from a Wishlist
@@ -374,10 +520,12 @@ def delete_wishlist_item(wishlist_id, item_id):
 
     item.delete()
     app.logger.info("Item with ID: %d deleted.", item_id)
-    return {}, status.HTTP_204_NO_CONTENT
+    return "", status.HTTP_204_NO_CONTENT
 
 
-@app.route("/wishlists/<int:wishlist_id>", methods=["PUT"])
+######################################################################
+# UPDATE A WISHLIST
+######################################################################
 def update_wishlists(wishlist_id):
     """
     Update a Wishlist
@@ -387,7 +535,6 @@ def update_wishlists(wishlist_id):
     app.logger.info("Request to update wishlist with id: %s", wishlist_id)
     check_content_type("application/json")
 
-    # See if the wishlist exists and abort if it doesn't
     wishlist = Wishlist.find(wishlist_id)
     if not wishlist:
         abort(
@@ -395,7 +542,7 @@ def update_wishlists(wishlist_id):
             f"Wishlist with id '{wishlist_id}' was not found.",
         )
 
-    data = request.get_json()
+    data = request.get_json() or {}
 
     if not data or "name" not in data:
         abort(
@@ -419,7 +566,7 @@ def update_wishlists(wishlist_id):
 
     wishlist.update()
 
-    return jsonify(wishlist.serialize()), status.HTTP_200_OK
+    return wishlist.serialize(), status.HTTP_200_OK
 
 
 ######################################################################
@@ -439,7 +586,7 @@ def check_content_type(content_type) -> None:
             f"Content-Type must be {content_type}",
         )
 
-    if request.headers["Content-Type"] == content_type:
+    if request.mimetype == content_type:
         return
 
     app.logger.error("Invalid Content-Type: %s", request.headers["Content-Type"])
@@ -447,3 +594,144 @@ def check_content_type(content_type) -> None:
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
         f"Content-Type must be {content_type}",
     )
+
+
+######################################################################
+# RESTX Resource Wrappers
+######################################################################
+@api.route("/health")
+class HealthResource(Resource):
+    """Read-only health endpoint."""
+
+    @api.doc("health_check")
+    @api.marshal_with(health_model)
+    def get(self):
+        """Health endpoint for API clients."""
+        return {"status": "OK"}, status.HTTP_200_OK
+
+
+@api.route("/wishlists", strict_slashes=False)
+class WishlistCollection(Resource):
+    """Handles all interactions with collections of Wishlists."""
+
+    @api.doc(
+        "list_wishlists",
+        params={
+            "customer_id": "Filter wishlists by customer id",
+            "name": "Filter wishlists by name",
+            "description": "Filter wishlists by description",
+        },
+    )
+    @api.marshal_list_with(wishlist_model)
+    def get(self):
+        """Returns all of the Wishlists."""
+        return list_wishlists()
+
+    @api.doc("create_wishlists")
+    @api.response(status.HTTP_400_BAD_REQUEST, "The posted wishlist data was not valid")
+    @api.response(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, "Content-Type must be application/json")
+    @api.expect(create_wishlist_model)
+    @api.marshal_with(wishlist_model, code=status.HTTP_201_CREATED)
+    def post(self):
+        """Creates a Wishlist."""
+        return create_wishlists()
+
+
+@api.route("/wishlists/<int:wishlist_id>")
+@api.param("wishlist_id", "The Wishlist identifier")
+class WishlistResource(Resource):
+    """Allows the manipulation of a single Wishlist."""
+
+    @api.doc("get_wishlist")
+    @api.response(status.HTTP_404_NOT_FOUND, "Wishlist not found")
+    @api.marshal_with(wishlist_model)
+    def get(self, wishlist_id):
+        """Retrieve a Wishlist with the id."""
+        return get_wishlist(wishlist_id)
+
+    @api.doc("update_wishlists")
+    @api.response(status.HTTP_404_NOT_FOUND, "Wishlist not found")
+    @api.response(status.HTTP_400_BAD_REQUEST, "The posted wishlist data was not valid")
+    @api.response(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, "Content-Type must be application/json")
+    @api.expect(update_wishlist_model)
+    @api.marshal_with(wishlist_model)
+    def put(self, wishlist_id):
+        """Update a Wishlist with the id."""
+        return update_wishlists(wishlist_id)
+
+    @api.doc("delete_wishlists")
+    @api.response(status.HTTP_204_NO_CONTENT, "Wishlist deleted")
+    def delete(self, wishlist_id):
+        """Delete a Wishlist with the id."""
+        return delete_wishlists(wishlist_id)
+
+
+@api.route("/wishlists/<int:wishlist_id>/private")
+@api.param("wishlist_id", "The Wishlist identifier")
+class WishlistPrivateResource(Resource):
+    """Wishlist action resource."""
+
+    @api.doc("set_wishlist_private")
+    @api.response(status.HTTP_404_NOT_FOUND, "Wishlist not found")
+    @api.marshal_with(wishlist_model)
+    def post(self, wishlist_id):
+        """Set a Wishlist to private."""
+        return set_wishlist_private(wishlist_id)
+
+
+@api.route("/wishlists/<int:wishlist_id>/items", strict_slashes=False)
+@api.param("wishlist_id", "The Wishlist identifier")
+class WishlistItemCollection(Resource):
+    """Handles all interactions with collections of Wishlist items."""
+
+    @api.doc(
+        "list_wishlist_items",
+        params={"product_name": "Filter wishlist items by product name"},
+    )
+    @api.response(status.HTTP_404_NOT_FOUND, "Wishlist not found")
+    @api.marshal_list_with(item_model)
+    def get(self, wishlist_id):
+        """Returns all of the Items in a Wishlist."""
+        return list_wishlist_items(wishlist_id)
+
+    @api.doc("create_wishlist_items")
+    @api.response(status.HTTP_400_BAD_REQUEST, "The posted item data was not valid")
+    @api.response(status.HTTP_404_NOT_FOUND, "Wishlist not found")
+    @api.response(status.HTTP_409_CONFLICT, "Duplicate item")
+    @api.response(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, "Content-Type must be application/json")
+    @api.expect(create_item_model)
+    @api.marshal_with(item_model, code=status.HTTP_201_CREATED)
+    def post(self, wishlist_id):
+        """Creates an Item in a Wishlist."""
+        return create_wishlist_items(wishlist_id)
+
+
+@api.route("/wishlists/<int:wishlist_id>/items/<int:item_id>")
+@api.param("wishlist_id", "The Wishlist identifier")
+@api.param("item_id", "The Item identifier")
+class WishlistItemResource(Resource):
+    """Allows the manipulation of a single Wishlist item."""
+
+    @api.doc("get_wishlist_item")
+    @api.response(status.HTTP_404_NOT_FOUND, "Wishlist or item not found")
+    @api.marshal_with(item_model)
+    def get(self, wishlist_id, item_id):
+        """Retrieve an Item from a Wishlist by its id."""
+        return get_wishlist_item(wishlist_id, item_id)
+
+    @api.doc("update_wishlist_item")
+    @api.response(status.HTTP_404_NOT_FOUND, "Wishlist or item not found")
+    @api.response(status.HTTP_400_BAD_REQUEST, "The posted item data was not valid")
+    @api.response(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE, "Content-Type must be application/json")
+    @api.expect(create_item_model)
+    @api.marshal_with(item_model)
+    def put(self, wishlist_id, item_id):
+        """Update an Item in a Wishlist."""
+        return update_wishlist_item(wishlist_id, item_id)
+
+    @api.doc("delete_wishlist_item")
+    @api.response(status.HTTP_204_NO_CONTENT, "Item deleted")
+    @api.response(status.HTTP_404_NOT_FOUND, "Wishlist or item not found")
+    def delete(self, wishlist_id, item_id):
+        """Delete an Item from a Wishlist."""
+        return delete_wishlist_item(wishlist_id, item_id)

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -4,29 +4,32 @@
 <body style="font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.5;">
   <h1>Wishlist Service is Up</h1>
   <p><strong>Wishlist REST API Service</strong> v1.0.</p>
+  <p>Swagger documentation is available at <a href="/apidocs/">/apidocs/</a>.</p>
   <p>These are the routes we serve:</p>
   <h2>Service</h2>
   <table border="1" cellpadding="8" cellspacing="0">
     <tr><th>Method</th><th>Path</th><th>Description</th></tr>
-    <tr><td>GET</td><td>/health</td><td>Health check</td></tr>
+    <tr><td>GET</td><td>/api/health</td><td>Health check</td></tr>
+    <tr><td>GET</td><td>/apidocs/</td><td>Swagger UI</td></tr>
   </table>
   <h2>Wishlists</h2>
   <table border="1" cellpadding="8" cellspacing="0">
     <tr><th>Method</th><th>Path</th><th>Description</th></tr>
-    <tr><td>GET</td><td>/wishlists</td><td>List wishlists (supports ?customer_id=, ?name=, ?description=)</td></tr>
-    <tr><td>POST</td><td>/wishlists</td><td>Create a wishlist</td></tr>
-    <tr><td>GET</td><td>/wishlists/{wishlist_id}</td><td>Get one wishlist</td></tr>
-    <tr><td>PUT</td><td>/wishlists/{wishlist_id}</td><td>Update wishlist name/description</td></tr>
-    <tr><td>DELETE</td><td>/wishlists/{wishlist_id}</td><td>Delete a wishlist</td></tr>
+    <tr><td>GET</td><td>/api/wishlists</td><td>List wishlists (supports ?customer_id=, ?name=, ?description=)</td></tr>
+    <tr><td>POST</td><td>/api/wishlists</td><td>Create a wishlist</td></tr>
+    <tr><td>GET</td><td>/api/wishlists/{wishlist_id}</td><td>Get one wishlist</td></tr>
+    <tr><td>PUT</td><td>/api/wishlists/{wishlist_id}</td><td>Update wishlist name/description</td></tr>
+    <tr><td>DELETE</td><td>/api/wishlists/{wishlist_id}</td><td>Delete a wishlist</td></tr>
+    <tr><td>POST</td><td>/api/wishlists/{wishlist_id}/private</td><td>Set a wishlist to private</td></tr>
   </table>
   <h2>Wishlist Items</h2>
   <table border="1" cellpadding="8" cellspacing="0">
     <tr><th>Method</th><th>Path</th><th>Description</th></tr>
-    <tr><td>GET</td><td>/wishlists/{wishlist_id}/items</td><td>List items in a wishlist (supports ?product_name=)</td></tr>
-    <tr><td>POST</td><td>/wishlists/{wishlist_id}/items</td><td>Create an item in a wishlist</td></tr>
-    <tr><td>GET</td><td>/wishlists/{wishlist_id}/items/{item_id}</td><td>Get one item in a wishlist</td></tr>
-    <tr><td>PUT</td><td>/wishlists/{wishlist_id}/items/{item_id}</td><td>Update item in wishlist</td></tr>
-    <tr><td>DELETE</td><td>/wishlists/{wishlist_id}/items/{item_id}</td><td>Delete item from wishlist</td></tr>
+    <tr><td>GET</td><td>/api/wishlists/{wishlist_id}/items</td><td>List items in a wishlist (supports ?product_name=)</td></tr>
+    <tr><td>POST</td><td>/api/wishlists/{wishlist_id}/items</td><td>Create an item in a wishlist</td></tr>
+    <tr><td>GET</td><td>/api/wishlists/{wishlist_id}/items/{item_id}</td><td>Get one item in a wishlist</td></tr>
+    <tr><td>PUT</td><td>/api/wishlists/{wishlist_id}/items/{item_id}</td><td>Update item in wishlist</td></tr>
+    <tr><td>DELETE</td><td>/api/wishlists/{wishlist_id}/items/{item_id}</td><td>Delete item from wishlist</td></tr>
   </table>
   <h2>Create, Retrieve, Update, Delete, and Search Wishlists</h2>
   <p>Status: <span id="flash_message"></span></p>

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -1,4 +1,6 @@
 (function () {
+    const API_BASE_URL = "/api/wishlists";
+
     function getField(id) {
         return document.getElementById(id);
     }
@@ -160,7 +162,7 @@
 
     async function createWishlist() {
         try {
-            const wishlist = await requestJson("/wishlists", {
+            const wishlist = await requestJson(API_BASE_URL, {
                 method: "POST",
                 headers: {
                     "Accept": "application/json",
@@ -179,7 +181,7 @@
 
     async function searchWishlists() {
         try {
-            const wishlists = await requestJson("/wishlists" + buildSearchQuery(), {
+            const wishlists = await requestJson(API_BASE_URL + buildSearchQuery(), {
                 method: "GET",
                 headers: {
                     "Accept": "application/json"
@@ -199,7 +201,7 @@
     async function retrieveWishlist() {
         try {
             const wishlistId = parseWishlistId(getField("wishlist_id").value);
-            const wishlist = await requestJson("/wishlists/" + wishlistId, {
+            const wishlist = await requestJson(API_BASE_URL + "/" + wishlistId, {
                 method: "GET",
                 headers: {
                     "Accept": "application/json"
@@ -217,7 +219,7 @@
     async function updateWishlist() {
         try {
             const wishlistId = parseWishlistId(getField("wishlist_id").value);
-            const wishlist = await requestJson("/wishlists/" + wishlistId, {
+            const wishlist = await requestJson(API_BASE_URL + "/" + wishlistId, {
                 method: "PUT",
                 headers: {
                     "Accept": "application/json",
@@ -237,7 +239,7 @@
     async function deleteWishlist() {
         try {
             const wishlistId = parseWishlistId(getField("wishlist_id").value);
-            await requestJson("/wishlists/" + wishlistId, {
+            await requestJson(API_BASE_URL + "/" + wishlistId, {
                 method: "DELETE",
                 headers: {
                     "Accept": "application/json"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -30,7 +30,9 @@ from tests.factories import WishlistFactory, ItemFactory
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"
 )
-BASE_URL = "/wishlists"
+BASE_URL = "/api/wishlists"
+HEALTH_URL = "/api/health"
+DOCS_URL = "/apidocs/"
 
 
 ######################################################################
@@ -96,6 +98,8 @@ class TestYourResourceService(TestCase):
         self.assertIn("name", data)
         self.assertIn("version", data)
         self.assertIn("paths", data)
+        self.assertIn("/api/wishlists", data["paths"])
+        self.assertIn("/apidocs/", data["docs"])
         self.assertIn("endpoints", data)
 
     def test_index_returns_html_when_accept_html(self):
@@ -104,6 +108,7 @@ class TestYourResourceService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertIn("text/html", resp.headers.get("Content-Type", ""))
         self.assertIn(b"Wishlist Service is Up", resp.data)
+        self.assertIn(b"/apidocs/", resp.data)
 
     def test_index_html_contains_wishlist_ui(self):
         """It should return the wishlist UI for browser requests"""
@@ -118,11 +123,18 @@ class TestYourResourceService(TestCase):
         self.assertIn(b'id="search_results"', resp.data)
 
     def test_health_endpoint(self):
-        """It should return healthy status"""
-        resp = self.client.get("/health")
+        """It should return healthy status from the API prefix"""
+        resp = self.client.get(HEALTH_URL)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertIn("application/json", resp.headers.get("Content-Type", ""))
         self.assertEqual(resp.get_json(), {"status": "OK"})
+
+    def test_swagger_docs_endpoint(self):
+        """It should serve the Swagger UI"""
+        resp = self.client.get(DOCS_URL)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("text/html", resp.headers.get("Content-Type", ""))
+        self.assertIn(b"swagger-ui", resp.data.lower())
 
     # ----------------------------------------------------------
     # TEST LIST ALL WISHLISTS
@@ -131,7 +143,7 @@ class TestYourResourceService(TestCase):
     def test_list_all_wishlists(self):
         """It should List all Wishlists"""
         self._create_wishlists(5)
-        resp = self.client.get("/wishlists")
+        resp = self.client.get(BASE_URL)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 5)
@@ -140,7 +152,7 @@ class TestYourResourceService(TestCase):
         """It should List Wishlists filtered by customer_id"""
         wishlists = self._create_wishlists(3)
         target = wishlists[0]
-        resp = self.client.get(f"/wishlists?customer_id={target.customer_id}")
+        resp = self.client.get(f"{BASE_URL}?customer_id={target.customer_id}")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         for wl in data:
@@ -149,7 +161,7 @@ class TestYourResourceService(TestCase):
     def test_list_wishlists_by_customer_id_no_results(self):
         """It should return an empty list when customer_id has no wishlists"""
         self._create_wishlists(3)
-        resp = self.client.get("/wishlists?customer_id=0")
+        resp = self.client.get(f"{BASE_URL}?customer_id=0")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 0)
@@ -158,7 +170,7 @@ class TestYourResourceService(TestCase):
         """It should List Wishlists filtered by name"""
         wishlists = self._create_wishlists(3)
         target = wishlists[0]
-        resp = self.client.get(f"/wishlists?name={target.name}")
+        resp = self.client.get(f"{BASE_URL}?name={target.name}")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         for wl in data:
@@ -170,7 +182,7 @@ class TestYourResourceService(TestCase):
         WishlistFactory(description="Travel gear").create()
         WishlistFactory(description="Office setup").create()
 
-        resp = self.client.get("/wishlists?description=Office setup")
+        resp = self.client.get(f"{BASE_URL}?description=Office setup")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 2)
@@ -180,21 +192,21 @@ class TestYourResourceService(TestCase):
     def test_list_wishlists_by_description_no_results(self):
         """It should return an empty list when description has no wishlists"""
         self._create_wishlists(3)
-        resp = self.client.get("/wishlists?description=Does not exist")
+        resp = self.client.get(f"{BASE_URL}?description=Does not exist")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 0)
 
     def test_list_all_wishlists_empty(self):
         """It should return an empty list when no Wishlists exist"""
-        resp = self.client.get("/wishlists")
+        resp = self.client.get(BASE_URL)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         data = resp.get_json()
         self.assertEqual(len(data), 0)
 
     def test_list_wishlists_bad_customer_id(self):
         """It should return 400 when customer_id is not a valid integer"""
-        resp = self.client.get("/wishlists?customer_id=abc")
+        resp = self.client.get(f"{BASE_URL}?customer_id=abc")
         self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
 
     # ----------------------------------------------------------
@@ -608,6 +620,22 @@ class TestSadPaths(TestCase):
         data = response.get_json()
         self.assertIn("error", data)
         self.assertEqual(data["error"], "Method not Allowed")
+
+    def test_root_method_not_allowed_returns_json_405(self):
+        """It should return JSON for unsupported methods on non-API routes"""
+        response = self.client.patch("/")
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        data = response.get_json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"], "Method not Allowed")
+
+    def test_missing_route_returns_json_404(self):
+        """It should return JSON for missing non-API routes"""
+        response = self.client.get("/does-not-exist")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        data = response.get_json()
+        self.assertIn("error", data)
+        self.assertEqual(data["error"], "Not Found")
 
     def test_create_wishlist_no_data(self):
         """It should not Create a Wishlist with missing data"""


### PR DESCRIPTION
- Refactored the wishlist service to use `Flask-RESTX` with Swagger documentation.
- Added API docs at `/apidocs/` and moved REST endpoints under the `/api` prefix.
- Added Swagger models and annotations for wishlist and item request/response payloads.

