### PR TITLE
Implement Make Private UI action and BDD coverage for errors

### DIFF
--- a/features/steps/wishlist_steps.py
+++ b/features/steps/wishlist_steps.py
@@ -101,6 +101,30 @@ def step_retrieve_wishlist_by_id(context):
     context.driver.find_element(By.ID, "retrieve-btn").click()
 
 
+@when("I retrieve that wishlist again")
+def step_retrieve_wishlist_again(context):
+    """Retrieve the current wishlist again by id."""
+    step_retrieve_wishlist_by_id(context)
+
+
+@when("I make the wishlist private from the web UI")
+def step_make_wishlist_private_from_ui(context):
+    """Click Make Private for the current wishlist id."""
+    wishlist_id = str(context.wishlist["id"])
+    id_input = context.driver.find_element(By.ID, "wishlist_id")
+    id_input.clear()
+    id_input.send_keys(wishlist_id)
+    context.driver.find_element(By.ID, "make_private-btn").click()
+
+
+@when("I enter a wishlist ID that does not exist")
+def step_enter_missing_wishlist_id(context):
+    """Enter a wishlist id that is not present in storage."""
+    id_input = context.driver.find_element(By.ID, "wishlist_id")
+    id_input.clear()
+    id_input.send_keys("999999")
+
+
 @then("I should see the wishlist details")
 def step_see_wishlist_details(context):
     """Ensure retrieval succeeded and details are shown in UI."""
@@ -125,6 +149,48 @@ def step_see_correct_wishlist_information(context):
     assert context.driver.find_element(By.ID, "wishlist_customer_id").get_attribute(
         "value"
     ) == str(context.wishlist["customer_id"])
+
+
+@then("the wishlist should show a private status")
+def step_wishlist_shows_private_status(context):
+    """Ensure the UI marks the wishlist as private."""
+    found = WebDriverWait(context.driver, context.wait_seconds).until(
+        ec.text_to_be_present_in_element_value((By.ID, "wishlist_is_private"), "true")
+    )
+    assert found
+    table_text = context.driver.find_element(By.ID, "search_results").text
+    assert "Private" in table_text
+
+
+@then('I should see that "is_private" is true')
+def step_is_private_true(context):
+    """Assert private flag remains true after retrieval."""
+    found = WebDriverWait(context.driver, context.wait_seconds).until(
+        ec.text_to_be_present_in_element_value((By.ID, "wishlist_is_private"), "true")
+    )
+    assert found
+
+
+@then("I should see an error message indicating the wishlist ID is required or invalid")
+def step_wishlist_id_required_or_invalid(context):
+    """Check UI validation for missing or invalid wishlist id."""
+    WebDriverWait(context.driver, context.wait_seconds).until(
+        lambda drv: drv.find_element(By.ID, "flash_message").text.strip() != ""
+    )
+    message = context.driver.find_element(By.ID, "flash_message").text
+    assert (
+        "Wishlist ID is required" in message
+        or "Wishlist ID must be an integer" in message
+    )
+
+
+@then("I should see an error message indicating the wishlist was not found")
+def step_wishlist_not_found_error(context):
+    """Check UI error for missing wishlist id in backend."""
+    found = WebDriverWait(context.driver, context.wait_seconds).until(
+        ec.text_to_be_present_in_element((By.ID, "flash_message"), "not found")
+    )
+    assert found
 
 
 @given("multiple wishlists exist")

--- a/features/wishlist.feature
+++ b/features/wishlist.feature
@@ -39,3 +39,29 @@ Feature: Wishlist UI landing page
 		And multiple wishlists exist
 		When I search for wishlists
 		Then I should see more than one wishlist in the results
+
+	Scenario: Make an existing wishlist private from the web UI
+		Given I am on the "Home Page"
+		And a wishlist exists
+		When I retrieve the wishlist by ID
+		And I press the "Make Private" button
+		Then I should see the message "Success"
+		And the wishlist should show a private status
+
+	Scenario: Retrieve wishlist after making it private
+		Given I am on the "Home Page"
+		And a wishlist exists
+		When I make the wishlist private from the web UI
+		And I retrieve that wishlist again
+		Then I should see that "is_private" is true
+
+	Scenario: Make Private without a valid wishlist ID
+		Given I am on the "Home Page"
+		When I press the "Make Private" button
+		Then I should see an error message indicating the wishlist ID is required or invalid
+
+	Scenario: Make Private for a wishlist that does not exist
+		Given I am on the "Home Page"
+		When I enter a wishlist ID that does not exist
+		And I press the "Make Private" button
+		Then I should see an error message indicating the wishlist was not found

--- a/service/static/index.html
+++ b/service/static/index.html
@@ -18,6 +18,7 @@
     <tr><td>GET</td><td>/wishlists/{wishlist_id}</td><td>Get one wishlist</td></tr>
     <tr><td>PUT</td><td>/wishlists/{wishlist_id}</td><td>Update wishlist name/description</td></tr>
     <tr><td>DELETE</td><td>/wishlists/{wishlist_id}</td><td>Delete a wishlist</td></tr>
+    <tr><td>POST</td><td>/wishlists/{wishlist_id}/private</td><td>Action: set wishlist privacy to private</td></tr>
   </table>
   <h2>Wishlist Items</h2>
   <table border="1" cellpadding="8" cellspacing="0">
@@ -48,8 +49,13 @@
       <textarea id="wishlist_description" rows="4" cols="60"></textarea>
     </p>
     <p>
+      <label for="wishlist_is_private">Is Private:</label><br>
+      <input type="text" id="wishlist_is_private" readonly>
+    </p>
+    <p>
       <button type="button" id="create-btn">Create</button>
       <button type="button" id="retrieve-btn">Retrieve</button>
+      <button type="button" id="make_private-btn">Make Private</button>
       <button type="button" id="search-btn">Search</button>
     </p>
   </form>
@@ -60,11 +66,12 @@
           <th>ID</th>
           <th>Name</th>
           <th>Customer Id</th>
+          <th>Status</th>
           <th>Description</th>
         </tr>
       </thead>
       <tbody id="results_body">
-        <tr><td colspan="4">No wishlists loaded yet.</td></tr>
+        <tr><td colspan="5">No wishlists loaded yet.</td></tr>
       </tbody>
     </table>
   </div>

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -12,6 +12,7 @@
         getField("wishlist_name").value = wishlist.name || "";
         getField("wishlist_customer_id").value = wishlist.customer_id || "";
         getField("wishlist_description").value = wishlist.description || "";
+        getField("wishlist_is_private").value = wishlist.is_private === true ? "true" : "false";
     }
 
     function createCell(row, value) {
@@ -28,7 +29,7 @@
             const row = document.createElement("tr");
             row.className = "empty-row";
             const cell = document.createElement("td");
-            cell.colSpan = 4;
+            cell.colSpan = 5;
             cell.textContent = "No wishlists found.";
             row.appendChild(cell);
             body.appendChild(row);
@@ -40,6 +41,7 @@
             createCell(row, wishlist.id);
             createCell(row, wishlist.name);
             createCell(row, wishlist.customer_id);
+            createCell(row, wishlist.is_private === true ? "Private" : "Public");
             createCell(row, wishlist.description || "");
             body.appendChild(row);
         });
@@ -88,6 +90,10 @@
         const trimmed = rawValue.trim();
         if (!trimmed) {
             throw new Error("Wishlist ID is required");
+        }
+
+        if (!/^\d+$/.test(trimmed)) {
+            throw new Error("Wishlist ID must be an integer");
         }
 
         const parsed = Number.parseInt(trimmed, 10);
@@ -190,7 +196,33 @@
         }
     }
 
+    async function makeWishlistPrivate() {
+        try {
+            const wishlistId = parseWishlistId(getField("wishlist_id").value);
+            await requestJson("/wishlists/" + wishlistId + "/private", {
+                method: "POST",
+                headers: {
+                    "Accept": "application/json"
+                }
+            });
+
+            const wishlist = await requestJson("/wishlists/" + wishlistId, {
+                method: "GET",
+                headers: {
+                    "Accept": "application/json"
+                }
+            });
+
+            updateFormData(wishlist);
+            renderResults([wishlist]);
+            flashMessage("Success");
+        } catch (error) {
+            flashMessage(error.message);
+        }
+    }
+
     getField("create-btn").addEventListener("click", createWishlist);
     getField("retrieve-btn").addEventListener("click", retrieveWishlist);
+    getField("make_private-btn").addEventListener("click", makeWishlistPrivate);
     getField("search-btn").addEventListener("click", searchWishlists);
 })();

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -111,8 +111,10 @@ class TestYourResourceService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertIn(b'id="wishlist_name"', resp.data)
         self.assertIn(b'id="wishlist_customer_id"', resp.data)
+        self.assertIn(b'id="wishlist_is_private"', resp.data)
         self.assertIn(b'id="create-btn"', resp.data)
         self.assertIn(b'id="retrieve-btn"', resp.data)
+        self.assertIn(b'id="make_private-btn"', resp.data)
         self.assertIn(b'id="search_results"', resp.data)
 
     def test_health_endpoint(self):


### PR DESCRIPTION
Implements Action on the webUI #77: allow a wishlist administrator to make an existing wishlist private from the Home Page and verify the visibility change end-to-end.

Changes

- Added a Make Private button to the Home Page.
- Added private visibility display in UI (form field and results status).
- Wired frontend action to call POST /wishlists/{wishlist_id}/private using the current wishlist ID.
- On success, UI now shows Success and refreshes wishlist data.
- Added UI error handling for missing/invalid ID and not-found wishlist.
- Added Selenium BDD scenarios and step definitions for all acceptance criteria.

Acceptance Criteria Covered

- Retrieve wishlist, click Make Private, see Success, and see private status.
- Make wishlist private, retrieve again, confirm is_private is true.
- Click Make Private with missing/invalid ID, see validation error.
- Click Make Private with non-existent ID, see not-found error.

Validation

- Unit tests: 89 passed.
- Coverage: 97.60% (threshold: 95%).
- New Make Private BDD scenarios: all passed.