### PR TITLE
Add Tekton pylint lint task in CD pipeline

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -11,6 +11,10 @@ spec:
       description: The reference (branch or ref)
       name: GIT_REF
       type: string
+    - default: python:3.12-slim
+      description: Base image used by lint and test tasks
+      name: IMAGE
+      type: string
   tasks:
     - name: git-clone
       params:
@@ -45,6 +49,23 @@ spec:
         - git-clone
       taskRef:
         name: run-unit-tests
+    - name: lint
+      runAfter:
+        - git-clone
+      taskRef:
+        name: lint
+      params:
+        - name: IMAGE
+          value: $(params.IMAGE)
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+    - name: sample
+      runAfter:
+        - unit-tests
+        - lint
+      taskRef:
+        name: sample
       workspaces:
         - name: source
           workspace: pipeline-workspace

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -49,6 +49,9 @@ spec:
         - git-clone
       taskRef:
         name: run-unit-tests
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
     - name: lint
       runAfter:
         - git-clone

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -69,3 +69,43 @@ spec:
         fi
       args:
         - "$(params.pytest-args[*])"
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: lint
+spec:
+  params:
+    - name: IMAGE
+      type: string
+      default: python:3.12-slim
+  workspaces:
+    - name: source
+  steps:
+    - name: run-lint
+      image: $(params.IMAGE)
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -e
+        python -m pip install --upgrade pip pipenv
+        pipenv install --dev
+        status=0
+        pipenv run flake8 service tests --count --select=E9,F63,F7,F82 --show-source --statistics || status=$?
+        pipenv run flake8 service tests --count --max-complexity=10 --max-line-length=127 --statistics || status=$?
+        pipenv run pylint service tests --max-line-length=127 || status=$?
+        exit $status
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: sample
+spec:
+  workspaces:
+    - name: source
+  steps:
+    - name: done
+      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+      script: |
+        #!/usr/bin/env sh
+        echo "sample task completed"


### PR DESCRIPTION
**Summary**

- Add a lint task in .tekton/tasks.yaml to run flake8 and pylint in the pipeline.
- Update lint execution to run directly via pipenv commands (remove dependency on make in task container).
- Wire pipeline so lint and unit-test run in parallel after git-clone.
- Keep downstream sample task dependent on both lint and test completion.

**Verification**

- Applied Tekton manifests:
    - oc apply -f .tekton/workspace.yaml
    - oc apply -f .tekton/tasks.yaml
    - oc apply -f .tekton/pipeline.yaml
- Started pipeline with branch 83-cd-pylint-task.
- Confirmed git-clone succeeded.
- Confirmed lint task executed and passed (Your code has been rated at 10.00/10).

<img width="861" height="129" alt="Screenshot 2026-04-28 at 2 43 11 AM" src="https://github.com/user-attachments/assets/0668c545-09a4-4b03-bab7-3ad264f2b589" />
