### PR TITLE
Implement buildah task for OpenShift CD pipeline - Story #84

### DIFF
--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -1,0 +1,117 @@
+# Tekton CD Pipeline for Wishlist Service
+
+This directory contains Tekton pipeline definitions for continuous delivery (CD) of the Wishlist Service on OpenShift.
+
+## Overview
+
+The Tekton CD pipeline automates the build and deployment process with the following stages:
+
+1. **Clone**: Clones the git repository
+2. **Lint** (pylint): Runs Python linting checks
+3. **Test**: Executes unit tests with code coverage validation
+4. **Build** (buildah): Builds a container image and pushes it to a registry
+
+## Files
+
+- `tasks.yaml`: Defines individual Tekton tasks
+  - `clone`: Clones the source code repository
+  - `pylint`: Runs linting and code quality checks
+  - `test`: Executes unit tests
+  - `buildah`: Builds and pushes the container image
+
+- `pipeline.yaml`: Defines the overall pipeline orchestration
+  - `wishlist-cd-pipeline`: Main pipeline definition
+  - `wishlist-cd-pipeline-run`: Example PipelineRun for manual execution
+
+## Buildah Task Details
+
+The buildah task performs the following:
+
+### Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| IMAGE | Container image reference | `quay.io/rofrano/wishlist-service:latest` |
+| DOCKERFILE | Path to Dockerfile | `./Dockerfile` |
+| CONTEXT | Build context directory | `.` |
+| TLSVERIFY | Verify TLS on registry | `false` |
+| FORMAT | Image format (docker/oci) | `docker` |
+
+### Steps
+
+1. **build**: Uses buildah to build the container image
+   - Builds from the specified Dockerfile
+   - Applies labels and layers
+   - Outputs image in specified format
+
+2. **push**: Pushes the built image to the container registry
+   - Uses buildah push
+   - Handles TLS verification based on parameters
+   - Stores image in remote registry
+
+### Security
+
+- Runs with `privileged: true` to allow container operations
+- Uses buildah's stable image for compatibility
+
+## Task Execution Order
+
+```
+clone
+  ├── lint (pylint) ──┐
+  └── test ──────────┴──→ build (buildah)
+```
+
+The buildah task runs **after** both `test` and `lint` complete successfully, ensuring code quality before image creation.
+
+## Usage
+
+### Apply to OpenShift
+
+```bash
+# Apply tasks
+kubectl apply -f .tekton/tasks.yaml
+
+# Apply pipeline
+kubectl apply -f .tekton/pipeline.yaml
+```
+
+### Trigger Pipeline Run
+
+```bash
+# Apply the example PipelineRun
+kubectl apply -f .tekton/pipeline.yaml -o jsonpath='{.items[1]}'
+```
+
+### View Pipeline Status
+
+```bash
+# List pipeline runs
+kubectl get pipelineruns
+
+# Watch pipeline run
+kubectl describe pipelinerun <run-name>
+
+# Stream logs
+tkn pipelinerun logs <run-name> -f
+```
+
+## Environment Variables
+
+- `DATABASE_URI`: PostgreSQL connection string for test task
+
+## Acceptance Criteria Validation
+
+✓ **Given**: The "test" and "pylint" tasks are completed
+✓ **When**: The buildah task runs
+✓ **Then**: On OpenShift UI, completion is verifiable via:
+  - PipelineRun status in OpenShift web console
+  - Built image available in registry
+  - Pipeline execution logs showing buildah steps
+
+## Next Steps
+
+1. Create a Trigger to automatically run the pipeline on git push
+2. Configure authentication for private registries
+3. Add deployment tasks after image build
+4. Implement promotion pipeline for staging/production

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -1,0 +1,91 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: wishlist-cd-pipeline
+spec:
+  description: Wishlist CD Pipeline for building and deploying the service
+  params:
+    - name: repo-url
+      type: string
+      description: The URL of the git repository
+      default: https://github.com/CSCI-GA-2820-SP26-003/wishlists.git
+    - name: branch
+      type: string
+      description: The git branch to use
+      default: master
+    - name: image
+      type: string
+      description: Reference of the image to build
+      default: quay.io/rofrano/wishlist-service:latest
+  workspaces:
+    - name: shared-workspace
+      description: Shared workspace for pipeline execution
+  tasks:
+    - name: clone
+      taskRef:
+        name: clone
+      params:
+        - name: repo-url
+          value: $(params.repo-url)
+        - name: branch
+          value: $(params.branch)
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+    - name: lint
+      taskRef:
+        name: pylint
+      runAfter:
+        - clone
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: test
+      taskRef:
+        name: test
+      runAfter:
+        - clone
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+    - name: build
+      taskRef:
+        name: buildah
+      runAfter:
+        - test
+        - lint
+      params:
+        - name: IMAGE
+          value: $(params.image)
+        - name: DOCKERFILE
+          value: ./Dockerfile
+        - name: CONTEXT
+          value: .
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: wishlist-cd-pipeline-run
+  generateName: wishlist-cd-pipeline-run-
+spec:
+  pipelineRef:
+    name: wishlist-cd-pipeline
+  params:
+    - name: repo-url
+      value: https://github.com/CSCI-GA-2820-SP26-003/wishlists.git
+    - name: branch
+      value: master
+    - name: image
+      value: quay.io/rofrano/wishlist-service:latest
+  workspaces:
+    - name: shared-workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          resources:
+            requests:
+              storage: 1Gi
+  serviceAccountName: pipeline

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -20,3 +20,98 @@ spec:
       script: |
         git clone --branch $(params.branch) $(params.repo-url) $(workspaces.output.path)
         echo "Cloned $(params.repo-url) branch $(params.branch)"
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: pylint
+spec:
+  description: Run pylint linting checks on Python code
+  workspaces:
+    - name: source
+      description: Workspace containing the source code
+  steps:
+    - name: run-pylint
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        python -m pip install -U pip pipenv
+        pipenv install --system --dev
+        make lint
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: test
+spec:
+  description: Run unit tests with code coverage
+  workspaces:
+    - name: source
+      description: Workspace containing the source code
+  steps:
+    - name: run-tests
+      image: python:3.12-slim
+      workingDir: $(workspaces.source.path)
+      script: |
+        python -m pip install -U pip pipenv
+        pipenv install --system --dev
+        apt-get update && apt-get install -y postgresql-client
+        pytest --pspec --cov=service --cov-fail-under=95 --cov-report=xml --disable-warnings
+      env:
+        - name: DATABASE_URI
+          value: postgresql+psycopg://postgres:postgres@postgres:5432/postgres
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: buildah
+spec:
+  description: Build and push a container image using buildah
+  params:
+    - name: IMAGE
+      type: string
+      description: Reference of the image to build
+      default: quay.io/rofrano/wishlist-service:latest
+    - name: DOCKERFILE
+      type: string
+      description: Path to the Dockerfile
+      default: ./Dockerfile
+    - name: CONTEXT
+      type: string
+      description: Path to build context
+      default: .
+    - name: TLSVERIFY
+      type: string
+      description: Verify the TLS on the registry endpoint
+      default: "false"
+    - name: FORMAT
+      type: string
+      description: The format of the image (docker or oci)
+      default: docker
+  workspaces:
+    - name: source
+      description: Workspace containing the source code to build
+  steps:
+    - name: build
+      image: quay.io/buildah/stable:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        buildah bud \
+          --format=$(params.FORMAT) \
+          --tls-verify=$(params.TLSVERIFY) \
+          --layers \
+          -f $(params.DOCKERFILE) \
+          -t $(params.IMAGE) \
+          $(params.CONTEXT)
+      securityContext:
+        privileged: true
+    - name: push
+      image: quay.io/buildah/stable:latest
+      workingDir: $(workspaces.source.path)
+      script: |
+        buildah push \
+          --tls-verify=$(params.TLSVERIFY) \
+          $(params.IMAGE) \
+          docker://$(params.IMAGE)
+      securityContext:
+        privileged: true


### PR DESCRIPTION
- Add buildah task to .tekton/tasks.yaml for building container images
- Add pylint task for Python code linting
- Add test task for unit testing with coverage validation
- Create complete Tekton Pipeline with task orchestration
- buildah task runs after test and pylint tasks complete
- Include parameters for image registry, Dockerfile path, and build context
- Add PipelineRun template for manual execution
- Document pipeline setup and acceptance criteria in README