### PR TITLE
Implement CD deploy task for story #85

### DIFF
--- a/.tekton/README.md
+++ b/.tekton/README.md
@@ -6,19 +6,20 @@ service CD flow.
 ## Files
 
 - `workspace.yaml`: PersistentVolumeClaim used by the pipeline workspace.
-- `tasks.yaml`: Custom tasks for unit tests, linting, and the Buildah image build.
-- `pipeline.yaml`: Pipeline orchestration for clone, test, lint, and image build.
+- `tasks.yaml`: Custom tasks for unit tests, linting, the Buildah image build, and deploy.
+- `pipeline.yaml`: Pipeline orchestration for clone, test, lint, image build, and deploy.
 
 ## Pipeline Flow
 
 ```text
 git-clone
   |-- unit-tests --|
-  |-- lint ------- |--> buildah
+  |-- lint ------- |--> buildah --> deploy
 ```
 
 The `buildah` pipeline task runs only after both `unit-tests` and `lint`
-complete successfully.
+complete successfully. The `deploy` task runs last and rolls out the exact
+image digest built by Buildah to the `wishlists` deployment.
 
 ## Pipeline Parameters
 
@@ -35,6 +36,7 @@ complete successfully.
 | `TLSVERIFY` | Verify TLS when pushing to the image registry | `false` |
 | `FORMAT` | Image manifest format | `docker` |
 | `STORAGE_DRIVER` | Buildah storage driver | `vfs` |
+| `DEPLOYER_IMAGE` | OpenShift CLI image used by the deploy task | `quay.io/openshift/origin-cli:4.18` |
 
 The Buildah task runs as a non-root user with user namespaces and `vfs` storage.
 This avoids requiring the `pipeline` service account to run privileged TaskRun
@@ -49,5 +51,4 @@ kubectl apply -f .tekton/pipeline.yaml
 ```
 
 After starting a PipelineRun in the OpenShift console, verify that the
-`buildah` task starts after `unit-tests` and `lint`, then completes
-successfully.
+`deploy` task starts after `buildah`, then completes successfully.

--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -47,6 +47,10 @@ spec:
       description: Buildah storage driver
       name: STORAGE_DRIVER
       type: string
+    - default: quay.io/openshift/origin-cli:4.18
+      description: OpenShift CLI image used by the deploy task
+      name: DEPLOYER_IMAGE
+      type: string
   tasks:
     - name: git-clone
       params:
@@ -114,6 +118,19 @@ spec:
           value: $(params.FORMAT)
         - name: STORAGE_DRIVER
           value: $(params.STORAGE_DRIVER)
+      workspaces:
+        - name: source
+          workspace: pipeline-workspace
+    - name: deploy
+      runAfter:
+        - buildah
+      taskRef:
+        name: deploy
+      params:
+        - name: IMAGE
+          value: $(params.REGISTRY)/$(context.pipelineRun.namespace)/$(params.IMAGE_NAME)@$(tasks.buildah.results.IMAGE_DIGEST)
+        - name: CLI_IMAGE
+          value: $(params.DEPLOYER_IMAGE)
       workspaces:
         - name: source
           workspace: pipeline-workspace

--- a/.tekton/tasks.yaml
+++ b/.tekton/tasks.yaml
@@ -203,3 +203,48 @@ spec:
   volumes:
     - name: varlibcontainers
       emptyDir: {}
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: deploy
+spec:
+  description: Deploy the Wishlist service and PostgreSQL to OpenShift.
+  params:
+    - name: IMAGE
+      type: string
+      description: Fully qualified image name to deploy.
+    - name: CLI_IMAGE
+      type: string
+      description: OpenShift CLI image used to apply manifests.
+      default: quay.io/openshift/origin-cli:4.18
+    - name: DEPLOYMENT_NAME
+      type: string
+      description: Wishlist deployment name.
+      default: wishlists
+    - name: CONTAINER_NAME
+      type: string
+      description: Wishlist container name in the deployment.
+      default: wishlists
+  workspaces:
+    - name: source
+      description: Workspace containing the Kubernetes manifests.
+  steps:
+    - name: apply-manifests
+      image: $(params.CLI_IMAGE)
+      workingDir: $(workspaces.source.path)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        oc apply -f k8s/postgres/secret.yaml
+        oc apply -f k8s/postgres/service.yaml
+        oc apply -f k8s/postgres/statefulset.yaml
+        oc rollout status statefulset/wishlists-db --timeout=180s
+
+        oc apply -f k8s/service.yaml
+        oc set image --local -f k8s/deployment.yaml -o yaml \
+          $(params.CONTAINER_NAME)=$(params.IMAGE) | oc apply -f -
+        oc rollout status deployment/$(params.DEPLOYMENT_NAME) --timeout=180s
+        oc wait --for=condition=available \
+          deployment/$(params.DEPLOYMENT_NAME) --timeout=180s

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,21 @@ FROM quay.io/rofrano/nyu-devops-base:sp26
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PORT=8080
+    PORT=8080 \
+    PATH="/home/vscode/.local/bin:$PATH" \
+    PYTHONPATH="/home/vscode/.local/lib/python3.12/site-packages"
 
 WORKDIR /app
 
 COPY Pipfile Pipfile.lock ./
 
 RUN python -m pip install --upgrade pip pipenv \
-    && pipenv install --system --dev
+    && pipenv install --system --dev \
+    && chmod a+rx /home/vscode \
+    && chmod -R a+rX /home/vscode/.local
 
 COPY . .
 
 EXPOSE 8080
 
-CMD ["gunicorn", "--bind", "0.0.0.0:8080", "--log-level=info", "wsgi:app"]
+CMD ["/home/vscode/.local/bin/gunicorn", "--bind", "0.0.0.0:8080", "--log-level=info", "wsgi:app"]


### PR DESCRIPTION
Add an OpenShift deploy Tekton task that runs after Buildah, applies the PostgreSQL and Wishlist Kubernetes manifests, injects the freshly built image into the Deployment, and waits for rollout completion. Update the CD pipeline documentation and run the container through Python's Gunicorn module so the deployed image starts successfully under OpenShift.